### PR TITLE
Impl std::error:Error for EnrError

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -21,11 +21,11 @@ pub enum EnrError {
 impl fmt::Display for EnrError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            EnrError::ExceedsMaxSize => write!(f, "enr exceeds max size"),
-            EnrError::SequenceNumberTooHigh => write!(f, "sequence number too large"),
-            EnrError::SigningError => write!(f, "signing error"),
-            EnrError::UnsupportedIdentityScheme => write!(f, "unsupported identity scheme"),
-            EnrError::InvalidRlpData(_rlp) => write!(f, "invalid rlp data"),
+            Self::ExceedsMaxSize => write!(f, "enr exceeds max size"),
+            Self::SequenceNumberTooHigh => write!(f, "sequence number too large"),
+            Self::SigningError => write!(f, "signing error"),
+            Self::UnsupportedIdentityScheme => write!(f, "unsupported identity scheme"),
+            Self::InvalidRlpData(_rlp) => write!(f, "invalid rlp data"),
         }
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,33 @@
+//! The error type emitted for various ENR operations.
+
+use std::error::Error;
+use std::fmt;
+
+#[derive(Clone, Debug)]
+/// An error type for handling various ENR operations.
+pub enum EnrError {
+    /// The ENR is too large.
+    ExceedsMaxSize,
+    /// The sequence number is too large.
+    SequenceNumberTooHigh,
+    /// There was an error with signing an ENR record.
+    SigningError,
+    /// The identity scheme is not supported.
+    UnsupportedIdentityScheme,
+    /// The entered RLP data is invalid.
+    InvalidRlpData(String),
+}
+
+impl fmt::Display for EnrError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            EnrError::ExceedsMaxSize => write!(f, "enr exceeds max size"),
+            EnrError::SequenceNumberTooHigh => write!(f, "sequence number too large"),
+            EnrError::SigningError => write!(f, "signing error"),
+            EnrError::UnsupportedIdentityScheme => write!(f, "unsupported identity scheme"),
+            EnrError::InvalidRlpData(_rlp) => write!(f, "invalid rlp data"),
+        }
+    }
+}
+
+impl Error for EnrError {}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -178,6 +178,7 @@
 )]
 
 mod builder;
+mod error;
 mod keys;
 mod node_id;
 
@@ -198,6 +199,7 @@ use std::{
 };
 
 pub use builder::EnrBuilder;
+pub use error::EnrError;
 
 #[cfg(feature = "k256")]
 pub use keys::k256;
@@ -922,21 +924,6 @@ impl<K: EnrKey> rlp::Decodable for Enr<K> {
         }
         Ok(enr)
     }
-}
-
-#[derive(Clone, Debug)]
-/// An error type for handling various ENR operations.
-pub enum EnrError {
-    /// The ENR is too large.
-    ExceedsMaxSize,
-    /// The sequence number is too large.
-    SequenceNumberTooHigh,
-    /// There was an error with signing an ENR record.
-    SigningError,
-    /// The identity scheme is not supported.
-    UnsupportedIdentityScheme,
-    /// The entered RLP data is invalid.
-    InvalidRlpData(String),
 }
 
 pub(crate) fn digest(b: &[u8]) -> [u8; 32] {


### PR DESCRIPTION
Implements std::error:Error for `EnrError`