### PR TITLE
[secp256k1] Add additional data when creating ECDSA signature

### DIFF
--- a/src/keys/rust_secp256k1.rs
+++ b/src/keys/rust_secp256k1.rs
@@ -26,8 +26,7 @@ impl EnrKey for secp256k1::SecretKey {
         let signature = {
             let mut noncedata = [0; 32];
             OsRng.fill_bytes(&mut noncedata);
-            let signature = SECP256K1.sign_ecdsa_with_noncedata(&m, self, &noncedata);
-            signature
+            SECP256K1.sign_ecdsa_with_noncedata(&m, self, &noncedata)
         };
         Ok(signature.serialize_compact().to_vec())
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1080,6 +1080,49 @@ mod tests {
         assert!(decoded_enr.verify());
     }
 
+    #[cfg(feature = "rust-secp256k1")]
+    #[test]
+    fn test_secp256k1_sign_ecdsa_with_mock_noncedata() {
+        // Uses the example record from the ENR spec.
+        //
+        // The feature "rust-secp256k1" creates ECDSA signatures with additional random data.
+        // Under the unit testing environment, the mock value `MOCK_ECDSA_NONCE_ADDITIONAL_DATA`
+        // is always used.
+        //
+        // The expected ENR textual form `expected_enr_base64` is constructed by a Python script:
+        // ```
+        // key = SigningKey.from_secret_exponent(
+        //     0xb71c71a67e1177ad4e901695e1b4b9ee17ae16c6668d313eac2f96dbcda3f291, curve=SECP256k1)
+        //
+        // # Builds content RLP
+        // rlp_data = encode([1, 'id', 'v4', 'ip', 0x7f000001, 'secp256k1', bytes.fromhex(
+        //     '03ca634cae0d49acb401d8a4c6b6fe8c55b70d115bf400769cc1400f3258cd3138'), 'udp', 0x765f])
+        // rlp_data_hash = keccak(rlp_data)
+        //
+        // # Signs the content RLP **with** the additional data.
+        // additional_data = bytes.fromhex(
+        //     'baaaaaadbaaaaaadbaaaaaadbaaaaaadbaaaaaadbaaaaaadbaaaaaadbaaaaaad')
+        // content_signature = key.sign_digest_deterministic(rlp_data_hash, hashfunc=sha256,
+        //                                                   sigencode=sigencode_string_canonize,
+        //                                                   extra_entropy=additional_data)
+        // rlp_with_signature = encode(
+        //     [content_signature, 1, 'id', 'v4', 'ip', 0x7f000001, 'secp256k1', bytes.fromhex(
+        //         '03ca634cae0d49acb401d8a4c6b6fe8c55b70d115bf400769cc1400f3258cd3138'), 'udp', 0x765f])
+        // textual_form = "enr:" + urlsafe_b64encode(rlp_with_signature).decode('utf-8').rstrip('=')
+        // ```
+        let expected_enr_base64 = "enr:-IS4QLJYdRwxdy-AbzWC6wL9ooB6O6uvCvJsJ36rbJztiAs1JzPY0__YkgFzZwNUuNhm1BDN6c4-UVRCJP9bXNCmoDYBgmlkgnY0gmlwhH8AAAGJc2VjcDI1NmsxoQPKY0yuDUmstAHYpMa2_oxVtw0RW_QAdpzBQA8yWM0xOIN1ZHCCdl8";
+
+        let key_data =
+            hex::decode("b71c71a67e1177ad4e901695e1b4b9ee17ae16c6668d313eac2f96dbcda3f291")
+                .unwrap();
+        let ip = Ipv4Addr::new(127, 0, 0, 1);
+        let udp = 30303;
+
+        let key = secp256k1::SecretKey::from_slice(&key_data).unwrap();
+        let enr = EnrBuilder::new("v4").ip4(ip).udp4(udp).build(&key).unwrap();
+        assert_eq!(enr.to_base64(), expected_enr_base64);
+    }
+
     #[cfg(feature = "k256")]
     #[test]
     fn test_encode_decode_k256() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1193,7 +1193,11 @@ mod tests {
 
         let key = secp256k1::SecretKey::from_slice(&key_data).unwrap();
         let enr = EnrBuilder::new("v4").ip4(ip).udp4(udp).build(&key).unwrap();
-        assert_eq!(enr.to_base64(), expected_enr_base64);
+        let enr_base64 = enr.to_base64();
+        assert_eq!(enr_base64, expected_enr_base64);
+
+        let enr = enr_base64.parse::<Enr<secp256k1::SecretKey>>().unwrap();
+        assert!(enr.verify());
     }
 
     #[cfg(feature = "k256")]

--- a/tests/ecdsa/main.rs
+++ b/tests/ecdsa/main.rs
@@ -1,0 +1,2 @@
+#[cfg(feature = "rust-secp256k1")]
+mod rust_secp256k1;

--- a/tests/ecdsa/rust_secp256k1.rs
+++ b/tests/ecdsa/rust_secp256k1.rs
@@ -1,0 +1,18 @@
+use enr::EnrBuilder;
+use std::net::Ipv4Addr;
+
+// Ensures the mock data is not used in the production environment.
+// See unit test `test_secp256k1_sign_ecdsa_with_mock_noncedata` for details.
+#[test]
+fn test_secp256k1_sign_ecdsa_with_noncedata() {
+    let not_expected_enr_base64 = "enr:-IS4QLJYdRwxdy-AbzWC6wL9ooB6O6uvCvJsJ36rbJztiAs1JzPY0__YkgFzZwNUuNhm1BDN6c4-UVRCJP9bXNCmoDYBgmlkgnY0gmlwhH8AAAGJc2VjcDI1NmsxoQPKY0yuDUmstAHYpMa2_oxVtw0RW_QAdpzBQA8yWM0xOIN1ZHCCdl8";
+
+    let key_data =
+        hex::decode("b71c71a67e1177ad4e901695e1b4b9ee17ae16c6668d313eac2f96dbcda3f291").unwrap();
+    let ip = Ipv4Addr::new(127, 0, 0, 1);
+    let udp = 30303;
+
+    let key = secp256k1::SecretKey::from_slice(&key_data).unwrap();
+    let enr = EnrBuilder::new("v4").ip4(ip).udp4(udp).build(&key).unwrap();
+    assert_ne!(enr.to_base64(), not_expected_enr_base64);
+}

--- a/tests/ecdsa/rust_secp256k1.rs
+++ b/tests/ecdsa/rust_secp256k1.rs
@@ -1,4 +1,4 @@
-use enr::EnrBuilder;
+use enr::{Enr, EnrBuilder};
 use std::net::Ipv4Addr;
 
 // Ensures the mock data is not used in the production environment.
@@ -14,5 +14,9 @@ fn test_secp256k1_sign_ecdsa_with_noncedata() {
 
     let key = secp256k1::SecretKey::from_slice(&key_data).unwrap();
     let enr = EnrBuilder::new("v4").ip4(ip).udp4(udp).build(&key).unwrap();
-    assert_ne!(enr.to_base64(), not_expected_enr_base64);
+    let enr_base64 = enr.to_base64();
+    assert_ne!(enr_base64, not_expected_enr_base64);
+
+    let enr = enr_base64.parse::<Enr<secp256k1::SecretKey>>().unwrap();
+    assert!(enr.verify());
 }


### PR DESCRIPTION
Hi, this is a trivial PR for a trivial issue, with no impact on the feature "k256", thereby deserving a low priority.
The update tries to remove one inconsistency in the ways the two features ("k256" and "rust-secp256k1") create ECDSA signatures.

The involved feature "rust-secp256k1" isn't being used by [discv5](https://github.com/sigp/discv5/blob/v0.1.0/Cargo.toml#L15). Maybe it's legacy code? Teams who use the feature might be interested in this change and taking time to review the updates.

An "issue" should have been created first, but with all the code already written during the experimental process, I'd like to present them here. 😃 


# Problem
The feature "rust-secp256k1" doesn't add additional data when creating signatures for the content RLP, while "k256" does.

Both features "k256" and "rust-secp256k1" uses RFC6979 to create deterministic nonces for ECDSA.
There is a slight difference through: "k256" [adds additional data](https://github.com/RustCrypto/elliptic-curves/blob/k256/v0.11.6/k256/src/ecdsa/sign.rs#L176) when creating the signature, 
"rust-secp256k1" does not. 

In other words, the signature created by the feature "rust-secp256k1" is completely deterministic for not applying additional random data. Made a quick [demo](https://github.com/weipin/enr_ecdsa_nonce_generating/blob/main/src/main.rs) to show the difference.   

# Refactor

## Code
The update is trivial by replacing `sign_ecdsa` with `sign_ecdsa_with_noncedata`. 
`OsRng` is used to "fill" the additional data, following the ["k256" code](https://github.com/sigp/enr/blob/v0.6.2/src/keys/k256_key.rs#L32). 

## Unit test
The tests use a mock structure `MockOsRng` with a specific value "0xbaaaaaad...".
All "rust_secp256k1" unit tests use this "baaaaaad" mock value as additional data.

The expected "enr:xxxx" was constructed by a [Python script](https://github.com/weipin/py_enr_demo/blob/main/main.py). The main part of that code snippet is included as comment.

## Integration test
Adds a new integration test (a new folder!) to ensure that the mock data won't be used in the production environment.
