### PR TITLE
Impl std::hash::Hash for Enr<K>

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -187,7 +187,8 @@ use log::debug;
 use rlp::{DecoderError, Rlp, RlpStream};
 use std::{
     collections::BTreeMap,
-    net::{SocketAddrV4, SocketAddrV6}, hash::{Hash, Hasher},
+    hash::{Hash, Hasher},
+    net::{SocketAddrV4, SocketAddrV6},
 };
 
 #[cfg(feature = "serde")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -187,7 +187,7 @@ use log::debug;
 use rlp::{DecoderError, Rlp, RlpStream};
 use std::{
     collections::BTreeMap,
-    net::{SocketAddrV4, SocketAddrV6},
+    net::{SocketAddrV4, SocketAddrV6}, hash::{Hash, Hasher},
 };
 
 #[cfg(feature = "serde")]
@@ -772,6 +772,16 @@ impl<K: EnrKey> std::cmp::Eq for Enr<K> {}
 impl<K: EnrKey> PartialEq for Enr<K> {
     fn eq(&self, other: &Self) -> bool {
         self.seq == other.seq && self.node_id == other.node_id && self.signature == other.signature
+    }
+}
+
+impl<K: EnrKey> Hash for Enr<K> {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.seq.hash(state);
+        self.node_id.hash(state);
+        // since the struct should always have a valid signature, we can hash the signature
+        // directly, rather than hashing the content.
+        self.signature.hash(state);
     }
 }
 


### PR DESCRIPTION
This allows `Enr<K>` to be used in data structures that require `Enr<K>` to implement `Hash` like a `HashSet` or `HashMap`. This also hashes only the `seq`, `node_id`, and `signature` fields, making it consistent with the `PartialEq` implementation.