### PR TITLE
NAT Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ increased.
 Different identity schemes can be used to define the node id and signatures. Currently only the
 "v4" identity is supported and is set by default.
 
+This crate also supports the [NAT extension](./docs/nat.md) for ENRs.
 ## Signing Algorithms
 
 User's wishing to implement their own singing algorithms simply need to

--- a/docs/nat.md
+++ b/docs/nat.md
@@ -27,33 +27,35 @@ Features may be added in the future.
 
 ### NAT
 
-The `nat` and `nat6` fields are used to indicate that the current node is
-behind a NAT and the external address in this field is only reachable via a
-hole-punching technique. 
+The `nat` and `nat6` fields are used to indicate how an external peer should
+attempt a connection to the local node. Setting these fields, indicate that the
+local node has identified itself as being behind a NAT and a hole-punching
+technique should be used to contact it.
 
 Nodes that have either the `nat` or `nat6` fields in their ENR, should not have
-the `ip` field set. Having both the `ip` field and `nat` field set is
+the corresponding `ip` field set. Having both the `ip` field and `nat` field set is
 considered an invalid configuration.
 
-#### Symmetric and Asymmetric NATs
+### Connections to an ENR
 
-An asymmetric NAT is one where the router maintains an external IP:PORT mapped
-to an internal node. Typically packets are restricted such that only external
-hosts that have been contacted by the local host can send packets through this
-mapping.
+The fields of an ENR should dictate how external peers are able to initiate 
+connections. The following general rules apply (this is detailed for the IPv4
+case but is generalised to the IPv6 case and corresponding fields):
 
-A symmetric NAT involves individual port mappings for every external host
-contacted by the local host. Each external host, therefore has its own port in
-which it can contact the local host via the external ip address. 
-
-For asymmetric NATs, nodes should put a known contactable external port for
-their mapping in either the `udp` or `udp6` fields in addition to the
-corresponding `nat` and/or `nat6` fields.
-
-For symmetric NATs, nodes should leave the `udp` or `udp6` fields unset and
-only set the `nat` and/or `nat6` fields in their ENR. 
-
-Thus, the different forms of NAT'd peers can be identified via the ENRs as:
-- Symmetric: `nat` and/or `nat6` field set, `udp` or `udp6` field unset.
-- Asymmetric: `nat` and/or `nat6` field set and the `udp` and/or `udp6` fields
-	set.
+- The `ip` and `nat` fields are absent. This indicates the peer is unsure of its
+external/reachable address.
+- The `ip` field is present and the `nat` field is absent. This indicates that
+	external peers can connect directly to the IP address given by the `ip`
+	field. The corresponding `udp` or `tcp` port can be used.
+- The `ip` field is absent and the `nat` field is present. There are two cases
+	here:
+	- The `udp` and/or the `tcp` port field is present. This indicates the peer
+		is behind a NAT and an appropriate hole-punching technique should be
+		used and can be contacted via the IP address in the `nat` field and the
+		port in either the `udp` or `tcp` port.
+	- The `udp` and `tcp` port fields are absent. This indicates the peer is
+		behind a NAT that maps each external connection to a new port
+		(Symmetric NAT). There is no contactable port to reach this peer.
+		Specific hole-punching techniques can be used to reach this peer. 
+- The `ip` and `nat` fields are both present. This is considered an invalid
+	configuration.

--- a/docs/nat.md
+++ b/docs/nat.md
@@ -9,6 +9,7 @@ hole-punching in [discv5](https://github.com/sigp/discv5).
 This library supports the following additional fields:
 
 | Key | Value |
+| --- | ----- |
 | `features` | A bitfield representing which features are supported |
 | `nat` | IPv4 address, 4 bytes, representing a NAT'd external IP address |
 | `nat6` | IPv6 address, 16 bytes, representing a NAT'd external IPv6 address |

--- a/docs/nat.md
+++ b/docs/nat.md
@@ -1,0 +1,58 @@
+# NAT Extension for ENRs
+
+This document details the extra fields added to ENRs to minimally support NAT
+hole-punching in [discv5](https://github.com/sigp/discv5).
+
+
+## Extended Fields
+
+This library supports the following additional fields:
+
+| Key | Value |
+| `features` | A bitfield representing which features are supported |
+| `nat` | IPv4 address, 4 bytes, representing a NAT'd external IP address |
+| `nat6` | IPv6 address, 16 bytes, representing a NAT'd external IPv6 address |
+
+### Features
+
+This field is a generic bitfield that allows ENRs to indicate which features
+they support. The current supported features are:
+- 1 - NAT_SUPPORT: Setting the first bit (big-endian) indicates that this node
+	supports NAT hole-punching. This means it can act as a relayer to
+	facilitate hole punching between other nodes that also support this
+	feature.
+
+Features may be added in the future.
+
+### NAT
+
+The `nat` and `nat6` fields are used to indicate that the current node is
+behind a NAT and the external address in this field is only reachable via a
+hole-punching technique. 
+
+Nodes that have either the `nat` or `nat6` fields in their ENR, should not have
+the `ip` field set. Having both the `ip` field and `nat` field set is
+considered an invalid configuration.
+
+#### Symmetric and Asymmetric NATs
+
+An asymmetric NAT is one where the router maintains an external IP:PORT mapped
+to an internal node. Typically packets are restricted such that only external
+hosts that have been contacted by the local host can send packets through this
+mapping.
+
+A symmetric NAT involves individual port mappings for every external host
+contacted by the local host. Each external host, therefore has its own port in
+which it can contact the local host via the external ip address. 
+
+For asymmetric NATs, nodes should put a known contactable external port for
+their mapping in either the `udp` or `udp6` fields in addition to the
+corresponding `nat` and/or `nat6` fields.
+
+For symmetric NATs, nodes should leave the `udp` or `udp6` fields unset and
+only set the `nat` and/or `nat6` fields in their ENR. 
+
+Thus, the different forms of NAT'd peers can be identified via the ENRs as:
+- Symmetric: `nat` and/or `nat6` field set, `udp` or `udp6` field unset.
+- Asymmetric: `nat` and/or `nat6` field set and the `udp` and/or `udp6` fields
+	set.

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -122,8 +122,8 @@ impl<K: EnrKey> EnrBuilder<K> {
     /// Adds an NAT `ip`/`ip6` field to the `ENRBuilder`.
     pub fn nat(&mut self, ip: IpAddr) -> &mut Self {
         match ip {
-            IpAddr::V4(addr) => self.ip4(addr),
-            IpAddr::V6(addr) => self.ip6(addr),
+            IpAddr::V4(addr) => self.nat4(addr),
+            IpAddr::V6(addr) => self.nat6(addr),
         }
     }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -14,6 +14,8 @@ pub enum EnrError {
     SigningError,
     /// The identity scheme is not supported.
     UnsupportedIdentityScheme,
+    /// The Nat configuration is incorrect.
+    NATConfigurationError,
     /// The entered RLP data is invalid.
     InvalidRlpData(String),
 }
@@ -25,6 +27,7 @@ impl fmt::Display for EnrError {
             Self::SequenceNumberTooHigh => write!(f, "sequence number too large"),
             Self::SigningError => write!(f, "signing error"),
             Self::UnsupportedIdentityScheme => write!(f, "unsupported identity scheme"),
+            Self::NATConfigurationError => write!(f, "NAT fields cannot be set with IP fields"),
             Self::InvalidRlpData(_rlp) => write!(f, "invalid rlp data"),
         }
     }

--- a/src/feature_bitfield.rs
+++ b/src/feature_bitfield.rs
@@ -1,0 +1,63 @@
+/// The kind of feature that can be supported.
+pub type Feature = u8;
+
+// Current Feature Map:
+// 1 - NAT - Is Nat supported
+
+/// Represents the decimal notation of the bitfield location for the feature.
+pub const NAT_FEATURE: Feature = 1;
+
+/// Discv5 Capable Features.
+///
+/// This is a bitfield that is stored inside ENRs to indicate which features of Discv5 are
+/// supported.
+/// Currently the only optional feature is NAT support. This consumes the first bit location.
+/// We currently store a single u8, which is fine as RLP encoding strips the leading 0s.
+#[derive(Clone, Debug, Default)]
+pub struct FeatureBitfield {
+    bitfield: u8, // Supports up to 256 unique features
+}
+
+impl FeatureBitfield {
+    /// Create a new instance of [`FeatureBitfield`].
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Sets the bitfield to indicate support for the NAT feature.
+    pub fn set_nat(&mut self) {
+        self.bitfield |= NAT_FEATURE;
+    }
+
+    /// Returns true if the NAT feature is set.
+    #[must_use]
+    pub const fn nat(&self) -> bool {
+        self.bitfield & NAT_FEATURE == NAT_FEATURE
+    }
+
+    /// Enables one or many features.
+    pub fn set_features(&mut self, features: Feature) {
+        self.bitfield |= features;
+    }
+
+    /// Returns if the feature is supported.
+    #[must_use]
+    pub const fn supports_feature(&self, feature: Feature) -> bool {
+        self.bitfield & feature == feature
+    }
+
+    /// Returns the decimal representation of the features supported.
+    #[must_use]
+    pub const fn features(&self) -> Feature {
+        self.bitfield
+    }
+}
+
+impl From<&[u8]> for FeatureBitfield {
+    fn from(src: &[u8]) -> Self {
+        Self {
+            bitfield: *src.first().unwrap_or(&0),
+        }
+    }
+}


### PR DESCRIPTION
This PR introduces a number of new fields and functionality designed to support automatic NAT hole-punching in discovery v5.

Although this is strictly not required in this crate, I think it might be good start in an attempt to standardize some of the ENR fields across client implementations.