### PR TITLE
fix: remove Base-suffix types in docs

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -175,7 +175,7 @@
     clippy::map_err_ignore,
     clippy::missing_errors_doc,
     clippy::module_name_repetitions,
-    clippy::option_if_let_else,
+    clippy::option_if_let_else
 )]
 
 mod builder;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -164,8 +164,8 @@
 //!
 //! [`CombinedKey`]: enum.CombinedKey.html
 //! [`EnrKey`]: trait.EnrKey.html
-//! [`Enr`]: struct.EnrBase.html
-//! [`EnrBuilder`]: struct.EnrBuilderBase.html
+//! [`Enr`]: struct.Enr.html
+//! [`EnrBuilder`]: struct.EnrBuilder.html
 //! [`NodeId`]: struct.NodeId.html
 //! [`insert`]: struct.Enr.html#method.insert
 //! [`get`]: struct.Enr.html#method.get

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -174,7 +174,8 @@
 #![allow(
     clippy::map_err_ignore,
     clippy::missing_errors_doc,
-    clippy::module_name_repetitions
+    clippy::module_name_repetitions,
+    clippy::option_if_let_else,
 )]
 
 mod builder;


### PR DESCRIPTION
Noticed that these links didn't go anywhere in the docs, so did the following:
 * Replace `EnrBase` with `Enr`
 * Replace `EnrBuilderBase` with `EnrBuilder`