### PR TITLE
refactor: swap Enr Debug and Display impl

### DIFF
--- a/src/node_id.rs
+++ b/src/node_id.rs
@@ -5,7 +5,7 @@ use crate::{digest, keys::EnrPublicKey, Enr, EnrKey};
 
 type RawNodeId = [u8; 32];
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+#[derive(Clone, Copy, PartialEq, Eq, Hash)]
 /// The `NodeId` of an ENR (a 32 byte identifier).
 pub struct NodeId {
     raw: RawNodeId,
@@ -91,6 +91,12 @@ impl std::fmt::Display for NodeId {
             &hex_encode[0..4],
             &hex_encode[hex_encode.len() - 4..]
         )
+    }
+}
+
+impl std::fmt::Debug for NodeId {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "0x{}", hex::encode(self.raw))
     }
 }
 


### PR DESCRIPTION
Closes #13

* swap Debug <-> Display impl
* Add NodeId Debug impl
* Include other fields in Enr Debug impl


Also ran clippy --fix

Example:

```text
Enr {
    id: Some(
        "v4",
    ),
    seq: 1,
    NodeId: 0x161d808320f6252ecaad817dd12154ec5d42d3b781eec1a414505c2ed74a03bc,
    signature: "5269b245b6a2e1c88c9a618c44aba7d4b6a58a8e2adf3e455889d1f3a9eecd2e58276bfda2ec62f3355427326ee3157864b920da95f81a5857e56cfcf9b8ea93",
    IpV4 UDP Socket: Some(
        127.0.0.1:3001,
    ),
    IpV6 UDP Socket: None,
    IpV4 TCP Socket: Some(
        127.0.0.1:3000,
    ),
    IpV6 TCP Socket: None,
    Other Pairs: [
        (
            "other",
            "836d7367",
        ),
        (
            "secp256k1",
            "a103bb51d4612f592c7d2d2114427191360dbeb4cd7941bed7264ab0e3d3c658257a",
        ),
    ],
}
```
