### PR TITLE
Serde NodeId

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ rlp = "0.5"
 zeroize = "1.1.0"
 sha3 = "0.10"
 k256 = { version = "0.13", features = ["ecdsa"], optional = true }
-serde = { version = "1.0.110", optional = true }
+serde = { version = "1.0.110", features = ["derive"], optional = true }
 ed25519-dalek = { version = "2.0.0-pre.0", optional = true, features = ["rand_core"] }
 secp256k1 = { version = "0.26", optional = true, default-features = false, features = [
     "global-context",
@@ -29,6 +29,7 @@ secp256k1 = { version = "0.26", optional = true, default-features = false, featu
 
 [dev-dependencies]
 secp256k1 = { features = ["rand-std"], version = "0.26" }
+serde_json = { version = "1.0.95" }
 
 [features]
 default = ["serde", "k256"]

--- a/src/node_id.rs
+++ b/src/node_id.rs
@@ -2,9 +2,12 @@
 //! keys this is the uncompressed encoded form of the public key).
 
 use crate::{digest, keys::EnrPublicKey, Enr, EnrKey};
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 
 type RawNodeId = [u8; 32];
 
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Clone, Copy, PartialEq, Eq, Hash)]
 /// The `NodeId` of an ENR (a 32 byte identifier).
 pub struct NodeId {
@@ -104,11 +107,22 @@ impl std::fmt::Debug for NodeId {
 mod tests {
     use super::*;
 
+    #[cfg(feature = "serde")]
+    use serde_json;
+
     #[test]
     fn test_eq_node_raw_node() {
         let node = NodeId::random();
         let raw = node.raw;
         assert_eq!(node, raw);
         assert_eq!(node.as_ref(), &raw[..]);
+    }
+
+    #[cfg(feature = "serde")]
+    #[test]
+    fn test_serde() {
+        let node = NodeId::random();
+        let json_string = serde_json::to_string(&node).unwrap();
+        assert_eq!(node, serde_json::from_str::<NodeId>(&json_string).unwrap());
     }
 }


### PR DESCRIPTION
### What was wrong?

The `NodeId` does not support Serialize/Deserialize.

### How was it fixed?

Add `Serde` on `NodeId` to support Serialize/Deserialize and a  corresponding JSON test.