### PR TITLE
Reachability check agnostic to ip version

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -756,6 +756,16 @@ impl<K: EnrKey> Enr<K> {
             .map(|_| {})
     }
 
+    /// Returns wether the node can be reached over UDP or not.
+    pub fn is_udp_reachable(&self) -> bool {
+        self.udp4_socket().is_some() || self.udp6_socket().is_some()
+    }
+
+    /// Returns wether the node can be reached over TCP or not.
+    pub fn is_tcp_reachable(&self) -> bool {
+        self.tcp4_socket().is_some() || self.tcp6_socket().is_some()
+    }
+
     // Private Functions //
 
     /// Evaluates the RLP-encoding of the content of the ENR record.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -757,11 +757,13 @@ impl<K: EnrKey> Enr<K> {
     }
 
     /// Returns wether the node can be reached over UDP or not.
+    #[must_use]
     pub fn is_udp_reachable(&self) -> bool {
         self.udp4_socket().is_some() || self.udp6_socket().is_some()
     }
 
     /// Returns wether the node can be reached over TCP or not.
+    #[must_use]
     pub fn is_tcp_reachable(&self) -> bool {
         self.tcp4_socket().is_some() || self.tcp6_socket().is_some()
     }


### PR DESCRIPTION
Confine logic of checking reachability of a node into one function for udp and one for tcp. Used for example when limiting sessions for symmetrically NAT:ed nodes.
