### PR TITLE
Check rlp size when creating a record from string

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -878,6 +878,9 @@ impl<K: EnrKey> FromStr for Enr<K> {
         }
         let bytes = base64::decode_config(decode_string, base64::URL_SAFE_NO_PAD)
             .map_err(|e| format!("Invalid base64 encoding: {e:?}"))?;
+        if bytes.len() > MAX_ENR_SIZE {
+            return Err("enr exceeds max size".to_string());
+        }
         rlp::decode(&bytes).map_err(|e| format!("Invalid ENR: {e:?}"))
     }
 }
@@ -1142,6 +1145,37 @@ mod tests {
     fn test_read_enr_prefix() {
         let text = "enr:-Iu4QM-YJF2RRpMcZkFiWzMf2kRd1A5F1GIekPa4Sfi_v0DCLTDBfOMTMMWJhhawr1YLUPb5008CpnBKrgjY3sstjfgCgmlkgnY0gmlwhH8AAAGJc2VjcDI1NmsxoQP8u1uyQFyJYuQUTyA1raXKhSw1HhhxNUQ2VE52LNHWMIN0Y3CCIyiDdWRwgiMo";
         text.parse::<DefaultEnr>().unwrap();
+    }
+
+    #[cfg(feature = "k256")]
+    #[test]
+    fn test_read_enr_reject_too_large_record() {
+        // 300-byte rlp encoded content, record creation should succeed.
+        let text = concat!("enr:-QEpuEDaLyrPP4gxBI9YL7QE9U1tZig_Nt8rue8bRIuYv_IMziFc8OEt3LQMwkwt6da-Z0Y8BaqkDalZbBq647UtV2ei",
+                           "AYJpZIJ2NIJpcIR_AAABiXNlY3AyNTZrMaEDymNMrg1JrLQB2KTGtv6MVbcNEVv0AHacwUAPMljNMTiDdWRwgnZferiieHh4",
+                           "eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4",
+                           "eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4",
+                           "eHh4eHh4eHh4eHh4eHh4");
+        let mut record = text.parse::<DefaultEnr>().unwrap();
+        // Ensures the size check when creating a record from string is
+        // consistent with the internal ones, such as when updating a record
+        // field.
+        let key_data =
+            hex::decode("b71c71a67e1177ad4e901695e1b4b9ee17ae16c6668d313eac2f96dbcda3f291")
+                .unwrap();
+        let key = k256::ecdsa::SigningKey::from_slice(&key_data).unwrap();
+        assert!(record.set_udp4(record.udp4().unwrap(), &key).is_ok());
+
+        // 301-byte rlp encoded content, record creation should fail.
+        let text = concat!("enr:-QEquEBxABglcZbIGKJ8RHDCp2Ft59tdf61RhV3XXf2BKTlKE2XwzNfihH-46hKkANsXaGRwH8Dp7a3lTrKiv2FMMaFY",
+                           "AYJpZIJ2NIJpcIR_AAABiXNlY3AyNTZrMaEDymNMrg1JrLQB2KTGtv6MVbcNEVv0AHacwUAPMljNMTiDdWRwgnZferijeHh4",
+                           "eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4",
+                           "eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4",
+                           "eHh4eHh4eHh4eHh4eHh4eA");
+        assert_eq!(
+            text.parse::<DefaultEnr>().unwrap_err(),
+            "enr exceeds max size"
+        );
     }
 
     /// Tests that RLP integers decoding rejects any item with leading zeroes.


### PR DESCRIPTION
# Problem

When creating a record (struct `ENR`) from its textual form ("enr:xxx"), it seems `MAX_ENR_SIZE` isn't checked.

To look at the issue from a different perspective, the code snippet below shows that the behavior when "reading from text" is inconsistent with the internal ones, such as when "updating a content field".

```Rust
use enr::k256::ecdsa::SigningKey;
use enr::{k256, Enr};
use hex_literal::hex;

type DefaultEnr = Enr<k256::ecdsa::SigningKey>;

fn main() {
    // The `key` is irrelevant here, for the resulting signature size is the same.
    let key = SigningKey::from_slice(&hex!("b71c71a67e1177ad4e901695e1b4b9ee17ae16c6668d313eac2f96dbcda3f291")).unwrap();

    // Address of a record with 301-byte rlp-encoded content.
    let text = "enr:-QEquEBxABglcZbIGKJ8RHDCp2Ft59tdf61RhV3XXf2BKTlKE2XwzNfihH-46hKkANsXaGRwH8Dp7a3lTrKiv2FMMaFYAYJpZIJ2NIJpcIR_AAABiXNlY3AyNTZrMaEDymNMrg1JrLQB2KTGtv6MVbcNEVv0AHacwUAPMljNMTiDdWRwgnZferijeHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eA";
    // Creating a record from the address succeeds (which probably should not).
    let mut record = text.parse::<DefaultEnr>().unwrap();
    // Updating the content field `udp` with the same value results an error.
    let err = record.set_udp4(record.udp4().unwrap(), &key).unwrap_err();
    assert_eq!(format!("{err}"), "enr exceeds max size");
}
```

# Solution

When creating a record from text, check the size of the rlp-encoded content. The check is made right before `rlp::decode(..)`, which seems to be the last place the rlp data is represented as bytes. The change should cover the serde feature, but no related tests are included.