### PR TITLE
serde(with = "SerHex::<StrictPfx>") NodeId

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ exclude = [".gitignore", ".github/*"]
 [dependencies]
 base64 = "0.21.0"
 bytes = "1"
-hex = "0.4.2"
+hex = {version = "0.4.2", features = ["serde"]}
 log = "0.4.8"
 rand = "0.8"
 rlp = "0.5"

--- a/src/node_id.rs
+++ b/src/node_id.rs
@@ -7,11 +7,12 @@ use serde::{Deserialize, Serialize};
 
 type RawNodeId = [u8; 32];
 
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize), serde(transparent))]
 #[derive(Clone, Copy, PartialEq, Eq, Hash)]
 /// The `NodeId` of an ENR (a 32 byte identifier).
 pub struct NodeId {
-    #[cfg_attr(feature = "serde", serde(with = "SerHex::<StrictPfx>"))] raw: RawNodeId,
+    #[cfg_attr(feature = "serde", serde(with = "hex::serde"))]
+    raw: RawNodeId,
 }
 
 impl NodeId {

--- a/src/node_id.rs
+++ b/src/node_id.rs
@@ -11,7 +11,7 @@ type RawNodeId = [u8; 32];
 #[derive(Clone, Copy, PartialEq, Eq, Hash)]
 /// The `NodeId` of an ENR (a 32 byte identifier).
 pub struct NodeId {
-    raw: RawNodeId,
+    #[cfg_attr(feature = "serde", serde(with = "SerHex::<StrictPfx>"))] raw: RawNodeId,
 }
 
 impl NodeId {

--- a/src/node_id.rs
+++ b/src/node_id.rs
@@ -107,6 +107,7 @@ impl std::fmt::Debug for NodeId {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::collections::HashMap;
 
     #[cfg(feature = "serde")]
     use serde_json;
@@ -125,5 +126,13 @@ mod tests {
         let node = NodeId::random();
         let json_string = serde_json::to_string(&node).unwrap();
         assert_eq!(node, serde_json::from_str::<NodeId>(&json_string).unwrap());
+    }
+
+    #[cfg(feature = "serde")]
+    #[test]
+    fn test_serde_as_hashmap_key() {
+        let mut responses: HashMap<NodeId, u8> = Default::default();
+        responses.insert(NodeId::random(), 1);
+        let _ = serde_json::json!(responses);
     }
 }


### PR DESCRIPTION
Without adding this if you tried to 

```rust
        let mut responses: HashMap<NodeId, u16> = Default::default();
        responses.insert(discv5::enr::NodeId::random(), 1);
        let hi = json!(responses);
```

json!(...) will fail with ``"key must be a string"``