### PR TITLE
do not turn on serde (from hex) when the serde feature is not on

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ exclude = [".gitignore", ".github/*"]
 [dependencies]
 base64 = "0.21.0"
 bytes = "1"
-hex = {version = "0.4.2", features = ["serde"]}
+hex = {version = "0.4.2"}
 log = "0.4.8"
 rand = "0.8"
 rlp = "0.5"
@@ -35,6 +35,7 @@ serde_json = { version = "1.0.95" }
 default = ["serde", "k256"]
 ed25519 = ["ed25519-dalek"]
 rust-secp256k1 = ["secp256k1"]
+serde = ["dep:serde", "hex/serde"]
 
 [lib]
 name = "enr"


### PR DESCRIPTION
cc @KolbyML 
missed from #34 