### PR TITLE
Serialize NodeId with `0x` prefix

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ zeroize = "1.1.0"
 sha3 = "0.10"
 k256 = { version = "0.13", features = ["ecdsa"], optional = true }
 serde = { version = "1.0.110", features = ["derive"], optional = true }
+serde-hex = { version = "0.1.0", optional = true}
 ed25519-dalek = { version = "2.0.0-pre.0", optional = true, features = ["rand_core"] }
 secp256k1 = { version = "0.27", optional = true, default-features = false, features = [
     "global-context",
@@ -35,7 +36,7 @@ serde_json = { version = "1.0.95" }
 default = ["serde", "k256"]
 ed25519 = ["ed25519-dalek"]
 rust-secp256k1 = ["secp256k1"]
-serde = ["dep:serde", "hex/serde"]
+serde = ["dep:serde", "dep:serde-hex"]
 
 [lib]
 name = "enr"

--- a/src/node_id.rs
+++ b/src/node_id.rs
@@ -4,6 +4,8 @@
 use crate::{digest, keys::EnrPublicKey, Enr, EnrKey};
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
+#[cfg(feature = "serde")]
+use serde_hex::{SerHex, StrictPfx};
 
 type RawNodeId = [u8; 32];
 
@@ -11,7 +13,7 @@ type RawNodeId = [u8; 32];
 #[derive(Clone, Copy, PartialEq, Eq, Hash)]
 /// The `NodeId` of an ENR (a 32 byte identifier).
 pub struct NodeId {
-    #[cfg_attr(feature = "serde", serde(with = "hex::serde"))]
+    #[cfg_attr(feature = "serde", serde(with = "SerHex::<StrictPfx>"))]
     raw: RawNodeId,
 }
 


### PR DESCRIPTION
So in my og pr [divagant-martian](https://github.com/divagant-martian) asked me if I wanted to use a 0x prefix or not and at the time I said that it didn't matter to me. I just had a meeting today and my team said they want a prefix since it ensures consistence with hex values, and it makes it easier to identify it as hex. It thought that was fair. So I am here today to try and get a 0x prefix :shipit: 