### PR TITLE
deps force min safe version of ed25519-dalek

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ sha3 = "0.10"
 k256 = { version = "0.13", features = ["ecdsa"], optional = true }
 serde = { version = "1.0.110", features = ["derive"], optional = true }
 serde-hex = { version = "0.1.0", optional = true}
-ed25519-dalek = { version = "2.0.0-pre.0", optional = true, features = ["rand_core"] }
+ed25519-dalek = { version = "2.0.0", optional = true, features = ["rand_core"] }
 secp256k1 = { version = "0.27", optional = true, default-features = false, features = [
     "global-context",
 ] }


### PR DESCRIPTION
a favor to dependants due to [`RUSTSEC-2022-0093`](https://rustsec.org/advisories/RUSTSEC-2022-0093)