### PR TITLE
Add `compare_content` function to `Enr` to allow comparisons modulo signature

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -423,7 +423,7 @@ impl<K: EnrKey> Enr<K> {
 
     /// Compare if the content of 2 Enr's match.
     #[must_use]
-    pub fn compare_content(&self, other: &Enr<K>) -> bool {
+    pub fn compare_content(&self, other: &Self) -> bool {
         self.rlp_content() == other.rlp_content()
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -421,6 +421,12 @@ impl<K: EnrKey> Enr<K> {
         }
     }
 
+    /// Compare if the content of 2 Enr's match.
+    #[must_use]
+    pub fn compare_content(&self, other: &Enr<K>) -> bool {
+        self.rlp_content() == other.rlp_content()
+    }
+
     /// Provides the URL-safe base64 encoded "text" version of the ENR prefixed by "enr:".
     #[must_use]
     pub fn to_base64(&self) -> String {
@@ -1701,6 +1707,35 @@ mod tests {
                 assert_tcp4(&res.unwrap(), tcp);
             }
         }
+    }
+
+    #[test]
+    fn test_compare_content() {
+        let key = k256::ecdsa::SigningKey::random(&mut rand::thread_rng());
+        let ip = Ipv4Addr::new(10, 0, 0, 1);
+        let tcp = 30303;
+
+        let enr1 = {
+            let mut builder = EnrBuilder::new("v4");
+            builder.ip4(ip);
+            builder.tcp4(tcp);
+            builder.build(&key).unwrap()
+        };
+
+        let mut enr2 = enr1.clone();
+        enr2.set_seq(1, &key).unwrap();
+        let mut enr3 = enr1.clone();
+        enr3.set_seq(2, &key).unwrap();
+
+        // Enr 1 & 2 should be equal, secpk256k1 should have different signatures for the same Enr content
+        assert_ne!(enr1.signature(), enr2.signature());
+        assert!(enr1.compare_content(&enr2));
+        assert_ne!(enr1, enr2);
+
+        // Enr 1 & 3 should not be equal, and have different signatures
+        assert_ne!(enr1.signature(), enr3.signature());
+        assert!(!enr1.compare_content(&enr3));
+        assert_ne!(enr1, enr3);
     }
 
     fn assert_tcp4(enr: &DefaultEnr, tcp: u16) {


### PR DESCRIPTION
I want an easy way to check if 2 Enr's are equal to each other.

Doing enr1 == enr2 doesn't work because you can have the same Enr with different signatures because of the random nouce I believe.

```nim
1Enr { id: Some("v4"), seq: 1, NodeId: 0x7c7c8dea6ad400ec9d52fec8e896484b5cb482e224e96d26fed48dc8b4351760, signature: "59a6e974107d34db2352a6518f38923d757f8c0fa16509de928c623ce3a5f472708ada60389170c9b58412595a9014d1e58c95e7cfc7a0bd61646f7679bbf694", IpV4 UDP Socket: Some(0.0.0.0:4444), IpV6 UDP Socket: None, IpV4 TCP Socket: None, IpV6 TCP Socket: None, Other Pairs: [("c", "967420302e312e312d616c7068612e312d336134623963"), ("secp256k1", "a1035d7c15bd8f796805b2d03d7bef6686b65659e0f2d3fc8163f35faf865379bc13")] }
2Enr { id: Some("v4"), seq: 1, NodeId: 0x7c7c8dea6ad400ec9d52fec8e896484b5cb482e224e96d26fed48dc8b4351760, signature: "9c6e457408f90025d5df6dd2e0c7e3f38496d79284b0af77cc0107ae1a23a61523177fd0de927e15cfd40255b658d4b315d5df85cdc3aa61946770ef1dfda2ea", IpV4 UDP Socket: Some(0.0.0.0:4444), IpV6 UDP Socket: None, IpV4 TCP Socket: None, IpV6 TCP Socket: None, Other Pairs: [("c", "967420302e312e312d616c7068612e312d336134623963"), ("secp256k1", "a1035d7c15bd8f796805b2d03d7bef6686b65659e0f2d3fc8163f35faf865379bc13")] }
3Enr { id: Some("v4"), seq: 1, NodeId: 0x7c7c8dea6ad400ec9d52fec8e896484b5cb482e224e96d26fed48dc8b4351760, signature: "ff3e36da2e8b69780cbf22b4d9699237b2d23b3a977fab85b5bdd3dd931f40a325a606fcf50758756bd533f057e51093e8a426d426da821b7029de92acf62bf7", IpV4 UDP Socket: Some(0.0.0.0:4444), IpV6 UDP Socket: None, IpV4 TCP Socket: None, IpV6 TCP Socket: None, Other Pairs: [("c", "967420302e312e312d616c7068612e312d336134623963"), ("secp256k1", "a1035d7c15bd8f796805b2d03d7bef6686b65659e0f2d3fc8163f35faf865379bc13")] }', portalnet/src/discovery.rs:509:9
```

Here is an example all 3 of these Enr's are the same except for the signatures, but all of the signatures are valid you could swap them and it wouldn't make a difference.

Currently there is no way to quickly check if 2 Enr's are the same because of this, without manually checking all the content. I don't want to manually do it ideally I could just do.

```rust
if enr1.verify_by_signature(enr2.signature) && enr2.verify_by_signature(enr1.signature) {
    todo:
}
```

or if we fix PartialEq will work like this for the edge case posted above
```rust
if enr1 == enr2 {
    todo:
}
```



I think PartialEq should work like this as well as comparing the signatures isn't a valid way to tell if the Enr's are the same or not.

I want to be able to do if enr1 == enr2 and it actually be a valid if case. Without the edge case I pointed to above, because right now doing ``enr1 == enr2`` just gives false information.

I think PartialEq should be instead like

```rust
impl<K: EnrKey> PartialEq for Enr<K> {
    fn eq(&self, other: &Self) -> bool {
        self.seq == other.seq && self.node_id == other.node_id && self.verify_by_signature(&other.signature) == other.verify_by_signature(&self.signature)
    }
}
```

As this would solve the edge case ^

```rust
impl<K: EnrKey> Hash for Enr<K> {
    fn hash<H: Hasher>(&self, state: &mut H) {
        self.seq.hash(state);
        self.node_id.hash(state);
        // since the struct should always have a valid signature, we can hash the signature
        // directly, rather than hashing the content.
        self.signature.hash(state);
    }
}
```
Here ^ we should not use the signature in the hash and instead just hash the RLP_CONTENT from that function. Since signatures are not deterministic as stated above.
