### PR TITLE
fix recovering from an error in `set_seq`

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -3,7 +3,7 @@
 use std::error::Error;
 use std::fmt;
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 /// An error type for handling various ENR operations.
 pub enum EnrError {
     /// The ENR is too large.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -814,7 +814,7 @@ impl<K: EnrKey> Enr<K> {
                 .sign_v4(&self.rlp_content())
                 .map_err(|_| EnrError::SigningError),
             // other identity schemes are unsupported
-            _ => return Err(EnrError::UnsupportedIdentityScheme),
+            _ => Err(EnrError::UnsupportedIdentityScheme),
         }
     }
 
@@ -1597,7 +1597,7 @@ mod tests {
 
         let (removed, inserted) = enr
             .remove_insert(
-                vec![b"tcp"].iter(),
+                [b"tcp"].iter(),
                 vec![(b"topics", topics)].into_iter(),
                 &key,
             )
@@ -1688,7 +1688,7 @@ mod tests {
             let mut enr = EnrBuilder::new("v4").build(&key).unwrap();
 
             let res = enr.remove_insert(
-                vec![b"none"].iter(),
+                [b"none"].iter(),
                 vec![(b"tcp".as_slice(), tcp.to_be_bytes().as_slice())].into_iter(),
                 &key,
             );
@@ -1780,6 +1780,6 @@ mod tests {
         assert_eq!(record, enr_bkp);
 
         record.set_seq(30, &key).unwrap();
-        assert_eq!(record.seq(), 30)
+        assert_eq!(record.seq(), 30);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -456,16 +456,15 @@ impl<K: EnrKey> Enr<K> {
             }
         };
 
-        // update the node id
-        let prev_node_id = std::mem::replace(&mut self.node_id, NodeId::from(key.public()));
-
         // check the size of the record
         if self.size() > MAX_ENR_SIZE {
             self.seq = prev_seq;
             self.signature = prev_signature;
-            self.node_id = prev_node_id;
             return Err(EnrError::ExceedsMaxSize);
         }
+
+        // update the node id
+        self.node_id = NodeId::from(key.public());
 
         Ok(())
     }
@@ -1596,11 +1595,7 @@ mod tests {
         let topics: &[u8] = &topics;
 
         let (removed, inserted) = enr
-            .remove_insert(
-                [b"tcp"].iter(),
-                vec![(b"topics", topics)].into_iter(),
-                &key,
-            )
+            .remove_insert([b"tcp"].iter(), vec![(b"topics", topics)].into_iter(), &key)
             .unwrap();
 
         assert_eq!(
@@ -1762,12 +1757,13 @@ mod tests {
     #[test]
     fn test_set_seq() {
         // 300 byte ENR (max size)
-        const LARGE_ENR : &str = 
-            concat!("enr:-QEpuEDaLyrPP4gxBI9YL7QE9U1tZig_Nt8rue8bRIuYv_IMziFc8OEt3LQMwkwt6da-Z0Y8BaqkDalZbBq647UtV2ei",
-                    "AYJpZIJ2NIJpcIR_AAABiXNlY3AyNTZrMaEDymNMrg1JrLQB2KTGtv6MVbcNEVv0AHacwUAPMljNMTiDdWRwgnZferiieHh4",
-                    "eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4",
-                    "eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4",
-                    "eHh4eHh4eHh4eHh4eHh4");
+        const LARGE_ENR : &str = concat!(
+            "enr:-QEpuEDaLyrPP4gxBI9YL7QE9U1tZig_Nt8rue8bRIuYv_IMziFc8OEt3LQMwkwt6da-Z0Y8BaqkDalZbBq647UtV2ei",
+            "AYJpZIJ2NIJpcIR_AAABiXNlY3AyNTZrMaEDymNMrg1JrLQB2KTGtv6MVbcNEVv0AHacwUAPMljNMTiDdWRwgnZferiieHh4",
+            "eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4",
+            "eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4",
+            "eHh4eHh4eHh4eHh4eHh4"
+        );
         let key = k256::ecdsa::SigningKey::random(&mut rand::thread_rng());
         let mut record = LARGE_ENR.parse::<DefaultEnr>().unwrap();
         let enr_bkp = record.clone();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1761,7 +1761,6 @@ mod tests {
     /// Tests [`Enr::set_seq`] in both a failure and success case.
     #[test]
     fn test_set_seq() {
-        
         // 300 byte ENR (max size)
         const LARGE_ENR : &str = 
             concat!("enr:-QEpuEDaLyrPP4gxBI9YL7QE9U1tZig_Nt8rue8bRIuYv_IMziFc8OEt3LQMwkwt6da-Z0Y8BaqkDalZbBq647UtV2ei",


### PR DESCRIPTION
Previous code left corrupted enrs in failure cases
also fixes some clippy failures that are really not too relevant