### PR TITLE
Improve builder ergonomics, remove prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ let mut rng = thread_rng();
 let key = k256::ecdsa::SigningKey::random(&mut rng);
 
 let ip = Ipv4Addr::new(192,168,0,1);
-let enr = Enr::v4_builder().ip4(ip).tcp4(8000).build(&key).unwrap();
+let enr = Enr::builder().ip4(ip).tcp4(8000).build(&key).unwrap();
 
 assert_eq!(enr.ip4(), Some("192.168.0.1".parse().unwrap()));
 assert_eq!(enr.id(), Some("v4".into()));
@@ -89,7 +89,7 @@ let key = CombinedKey::generate_secp256k1();
 let key = CombinedKey::generate_ed25519();
 
 let ip = Ipv4Addr::new(192,168,0,1);
-let enr = Enr::v4_builder().ip4(ip).tcp4(8000).build(&key).unwrap();
+let enr = Enr::builder().ip4(ip).tcp4(8000).build(&key).unwrap();
 
 assert_eq!(enr.ip4(), Some("192.168.0.1".parse().unwrap()));
 assert_eq!(enr.id(), Some("v4".into()));
@@ -113,7 +113,7 @@ let mut rng = thread_rng();
 let key = SigningKey::random(&mut rng);
 
 let ip = Ipv4Addr::new(192,168,0,1);
-let mut enr = Enr::v4_builder().ip4(ip).tcp4(8000).build(&key).unwrap();
+let mut enr = Enr::builder().ip4(ip).tcp4(8000).build(&key).unwrap();
 
 enr.set_tcp4(8001, &key);
 // set a custom key
@@ -143,7 +143,7 @@ use rand::Rng;
 let mut rng = thread_rng();
 let key = SigningKey::random(&mut rng);
 let ip = Ipv4Addr::new(192,168,0,1);
-let enr_secp256k1 = Enr::v4_builder().ip4(ip).tcp4(8000).build(&key).unwrap();
+let enr_secp256k1 = Enr::builder().ip4(ip).tcp4(8000).build(&key).unwrap();
 
 // encode to base64
 let base64_string_secp256k1 = enr_secp256k1.to_base64();
@@ -151,7 +151,7 @@ let base64_string_secp256k1 = enr_secp256k1.to_base64();
 // generate a random ed25519 key
 let mut rng = rand_07::thread_rng();
 let key = Keypair::generate(&mut rng);
-let enr_ed25519 = Enr::v4_builder().ip4(ip).tcp4(8000).build(&key).unwrap();
+let enr_ed25519 = Enr::builder().ip4(ip).tcp4(8000).build(&key).unwrap();
 
 // encode to base64
 let base64_string_ed25519 = enr_ed25519.to_base64();

--- a/README.md
+++ b/README.md
@@ -55,12 +55,10 @@ enr = { version = "*", features = ["serde", "ed25519", "rust-secp256k1"] }
 
 ## Examples
 
-To build an ENR, an `EnrBuilder` is provided.
-
 #### Building an ENR with the default `k256` key type
 
 ```rust
-use enr::{EnrBuilder, k256};
+use enr::{Enr, k256};
 use std::net::Ipv4Addr;
 use rand::thread_rng;
 
@@ -69,7 +67,7 @@ let mut rng = thread_rng();
 let key = k256::ecdsa::SigningKey::random(&mut rng);
 
 let ip = Ipv4Addr::new(192,168,0,1);
-let enr = EnrBuilder::new("v4").ip4(ip).tcp4(8000).build(&key).unwrap();
+let enr = Enr::v4_builder().ip4(ip).tcp4(8000).build(&key).unwrap();
 
 assert_eq!(enr.ip4(), Some("192.168.0.1".parse().unwrap()));
 assert_eq!(enr.id(), Some("v4".into()));
@@ -78,10 +76,10 @@ assert_eq!(enr.id(), Some("v4".into()));
 #### Building an ENR with the `CombinedKey` type (support for multiple signing algorithms).
 
 Note the `ed25519` feature flag must be set. This makes use of the
-`EnrBuilder` struct.
+`builder::Builder` struct.
 
 ```rust
-use enr::{EnrBuilder, CombinedKey};
+use enr::{Enr, CombinedKey};
 use std::net::Ipv4Addr;
 
 // create a new secp256k1 key
@@ -91,7 +89,7 @@ let key = CombinedKey::generate_secp256k1();
 let key = CombinedKey::generate_ed25519();
 
 let ip = Ipv4Addr::new(192,168,0,1);
-let enr = EnrBuilder::new("v4").ip4(ip).tcp4(8000).build(&key).unwrap();
+let enr = Enr::v4_builder().ip4(ip).tcp4(8000).build(&key).unwrap();
 
 assert_eq!(enr.ip4(), Some("192.168.0.1".parse().unwrap()));
 assert_eq!(enr.id(), Some("v4".into()));
@@ -103,7 +101,7 @@ ENR fields can be added and modified using the getters/setters on `Enr`. A custo
 can be added using `insert` and retrieved with `get`.
 
 ```rust
-use enr::{EnrBuilder, k256::ecdsa::SigningKey, Enr};
+use enr::{k256::ecdsa::SigningKey, Enr};
 use std::net::Ipv4Addr;
 use rand::thread_rng;
 
@@ -115,7 +113,7 @@ let mut rng = thread_rng();
 let key = SigningKey::random(&mut rng);
 
 let ip = Ipv4Addr::new(192,168,0,1);
-let mut enr = EnrBuilder::new("v4").ip4(ip).tcp4(8000).build(&key).unwrap();
+let mut enr = Enr::v4_builder().ip4(ip).tcp4(8000).build(&key).unwrap();
 
 enr.set_tcp4(8001, &key);
 // set a custom key
@@ -136,7 +134,7 @@ assert_eq!(decoded_enr.get("custom_key"), Some(vec![0,0,1].as_slice()));
 #### Encoding/Decoding ENR's of various key types
 
 ```rust
-use enr::{EnrBuilder, k256::ecdsa::SigningKey, Enr, ed25519_dalek::Keypair, CombinedKey};
+use enr::{k256::ecdsa::SigningKey, Enr, ed25519_dalek::Keypair, CombinedKey};
 use std::net::Ipv4Addr;
 use rand::thread_rng;
 use rand::Rng;
@@ -145,7 +143,7 @@ use rand::Rng;
 let mut rng = thread_rng();
 let key = SigningKey::random(&mut rng);
 let ip = Ipv4Addr::new(192,168,0,1);
-let enr_secp256k1 = EnrBuilder::new("v4").ip4(ip).tcp4(8000).build(&key).unwrap();
+let enr_secp256k1 = Enr::v4_builder().ip4(ip).tcp4(8000).build(&key).unwrap();
 
 // encode to base64
 let base64_string_secp256k1 = enr_secp256k1.to_base64();
@@ -153,7 +151,7 @@ let base64_string_secp256k1 = enr_secp256k1.to_base64();
 // generate a random ed25519 key
 let mut rng = rand_07::thread_rng();
 let key = Keypair::generate(&mut rng);
-let enr_ed25519 = EnrBuilder::new("v4").ip4(ip).tcp4(8000).build(&key).unwrap();
+let enr_ed25519 = Enr::v4_builder().ip4(ip).tcp4(8000).build(&key).unwrap();
 
 // encode to base64
 let base64_string_ed25519 = enr_ed25519.to_base64();

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -8,7 +8,7 @@ use std::{
 };
 
 /// The base builder for generating ENR records with arbitrary signing algorithms.
-pub struct EnrBuilder<K: EnrKey> {
+pub struct Builder<K: EnrKey> {
     /// The identity scheme used to build the ENR record.
     id: String,
 
@@ -23,13 +23,23 @@ pub struct EnrBuilder<K: EnrKey> {
     phantom: PhantomData<K>,
 }
 
-impl<K: EnrKey> EnrBuilder<K> {
-    /// Constructs a minimal `EnrBuilder` providing only a sequence number.
+impl<K: EnrKey> Builder<K> {
+    /// Constructs a minimal [`Builder`].
     /// Currently only supports the id v4 scheme and therefore disallows creation of any other
     /// scheme.
     pub fn new(id: impl Into<String>) -> Self {
         Self {
             id: id.into(),
+            seq: 1,
+            content: BTreeMap::new(),
+            phantom: PhantomData,
+        }
+    }
+
+    /// Constructs a minimal [`Builder`] for the v4 identity scheme.
+    pub fn new_v4() -> Self {
+        Self {
+            id: String::from("v4"),
             seq: 1,
             content: BTreeMap::new(),
             phantom: PhantomData,
@@ -137,7 +147,7 @@ impl<K: EnrKey> EnrBuilder<K> {
         self.add_value(key.enr_key(), &key.encode().as_ref());
     }
 
-    /// Constructs an ENR from the `EnrBuilder`.
+    /// Constructs an ENR from the [`Builder`].
     ///
     /// # Errors
     /// Fails if the identity scheme is not supported, or the record size exceeds `MAX_ENR_SIZE`.

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -23,9 +23,9 @@ pub struct Builder<K: EnrKey> {
     phantom: PhantomData<K>,
 }
 
-impl<K: EnrKey> Builder<K> {
+impl<K: EnrKey> Default for Builder<K> {
     /// Constructs a minimal [`Builder`] for the v4 identity scheme.
-    pub fn new() -> Self {
+    fn default() -> Self {
         Self {
             id: String::from("v4"),
             seq: 1,
@@ -33,7 +33,9 @@ impl<K: EnrKey> Builder<K> {
             phantom: PhantomData,
         }
     }
+}
 
+impl<K: EnrKey> Builder<K> {
     /// Modifies the sequence number of the builder.
     pub fn seq(&mut self, seq: u64) -> &mut Self {
         self.seq = seq;

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -24,20 +24,8 @@ pub struct Builder<K: EnrKey> {
 }
 
 impl<K: EnrKey> Builder<K> {
-    /// Constructs a minimal [`Builder`].
-    /// Currently only supports the id v4 scheme and therefore disallows creation of any other
-    /// scheme.
-    pub fn new(id: impl Into<String>) -> Self {
-        Self {
-            id: id.into(),
-            seq: 1,
-            content: BTreeMap::new(),
-            phantom: PhantomData,
-        }
-    }
-
     /// Constructs a minimal [`Builder`] for the v4 identity scheme.
-    pub fn new_v4() -> Self {
+    pub fn new() -> Self {
         Self {
             id: String::from("v4"),
             seq: 1,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1735,7 +1735,7 @@ mod tests {
         // hack an enr object that is too big. This is not possible via the public API.
         let key = k256::ecdsa::SigningKey::random(&mut rand::thread_rng());
 
-        let mut huge_enr = EnrBuilder::new("v4").build(&key).unwrap();
+        let mut huge_enr = Enr::empty_v4(&key).unwrap();
         let large_vec: Vec<u8> = std::iter::repeat(0).take(MAX_ENR_SIZE).collect();
         let large_vec_encoded = rlp::encode(&large_vec).freeze();
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -242,19 +242,14 @@ pub struct Enr<K: EnrKey> {
 impl<K: EnrKey> Enr<K> {
     /* Builders */
 
-    /// Get a [`builder::Builder`] with a given identity scheme.
-    pub fn builder(id: impl Into<String>) -> builder::Builder<K> {
-        builder::Builder::new(id)
-    }
-
-    /// Get a [`builder::Builder`] with the default identity scheme
-    pub fn v4_builder() -> builder::Builder<K> {
-        builder::Builder::new_v4()
+    /// Get a [`builder::Builder`] with the default identity scheme.
+    pub fn builder() -> builder::Builder<K> {
+        builder::Builder::new()
     }
 
     /// Get an empty Enr for the v4 identity scheme.
-    pub fn empty_v4(signing_key: &K) -> Result<Self, EnrError> {
-        Self::v4_builder().build(signing_key)
+    pub fn empty(signing_key: &K) -> Result<Self, EnrError> {
+        Self::builder().build(signing_key)
     }
 
     // getters //
@@ -1428,7 +1423,7 @@ mod tests {
         let ip = Ipv4Addr::new(127, 0, 0, 1);
         let tcp = 3000;
 
-        let enr = Enr::v4_builder().ip4(ip).tcp4(tcp).build(&key).unwrap();
+        let enr = Enr::builder().ip4(ip).tcp4(tcp).build(&key).unwrap();
 
         let encoded_enr = rlp::encode(&enr);
 
@@ -1470,7 +1465,7 @@ mod tests {
         let ip = Ipv4Addr::new(10, 0, 0, 1);
         let tcp = 30303;
 
-        let mut enr = Enr::v4_builder().ip4(ip).tcp4(tcp).build(&key).unwrap();
+        let mut enr = Enr::builder().ip4(ip).tcp4(tcp).build(&key).unwrap();
 
         enr.insert("random", &Vec::new(), &key).unwrap();
         assert!(enr.verify());
@@ -1483,7 +1478,7 @@ mod tests {
         let tcp = 30303;
         let ip = Ipv4Addr::new(10, 0, 0, 1);
 
-        let mut enr = Enr::v4_builder().tcp4(tcp).build(&key).unwrap();
+        let mut enr = Enr::builder().tcp4(tcp).build(&key).unwrap();
 
         assert!(enr.set_ip(ip.into(), &key).is_ok());
         assert_eq!(enr.id(), Some("v4".into()));
@@ -1503,7 +1498,7 @@ mod tests {
         let udp = 30304;
         let ip = Ipv4Addr::new(10, 0, 0, 1);
 
-        let mut enr = Enr::v4_builder()
+        let mut enr = Enr::builder()
             .ip4(ip)
             .tcp4(tcp)
             .udp4(udp)
@@ -1573,7 +1568,7 @@ mod tests {
         s.append(&"eth_syncing");
         topics.extend_from_slice(&s.out().freeze());
 
-        let mut enr = Enr::v4_builder().tcp4(tcp).build(&key).unwrap();
+        let mut enr = Enr::builder().tcp4(tcp).build(&key).unwrap();
 
         assert_eq!(enr.tcp4(), Some(tcp));
         assert_eq!(enr.get("topics"), None);
@@ -1610,7 +1605,7 @@ mod tests {
         let key = k256::ecdsa::SigningKey::random(&mut rand::thread_rng());
 
         for tcp in LOW_INT_PORTS {
-            let enr = Enr::v4_builder().tcp4(tcp).build(&key).unwrap();
+            let enr = Enr::builder().tcp4(tcp).build(&key).unwrap();
 
             assert_tcp4(&enr, tcp);
         }
@@ -1621,7 +1616,7 @@ mod tests {
         let key = k256::ecdsa::SigningKey::random(&mut rand::thread_rng());
 
         for tcp in LOW_INT_PORTS {
-            let mut enr = Enr::empty_v4(&key).unwrap();
+            let mut enr = Enr::empty(&key).unwrap();
             enr.set_tcp4(tcp, &key).unwrap();
             assert_tcp4(&enr, tcp);
         }
@@ -1633,7 +1628,7 @@ mod tests {
         let ipv4 = Ipv4Addr::new(127, 0, 0, 1);
 
         for tcp in LOW_INT_PORTS {
-            let mut enr = Enr::empty_v4(&key).unwrap();
+            let mut enr = Enr::empty(&key).unwrap();
             enr.set_socket(SocketAddr::V4(SocketAddrV4::new(ipv4, tcp)), &key, true)
                 .unwrap();
             assert_tcp4(&enr, tcp);
@@ -1645,7 +1640,7 @@ mod tests {
         let key = k256::ecdsa::SigningKey::random(&mut rand::thread_rng());
 
         for tcp in LOW_INT_PORTS {
-            let mut enr = Enr::empty_v4(&key).unwrap();
+            let mut enr = Enr::empty(&key).unwrap();
 
             let res = enr.insert(b"tcp", &tcp.to_be_bytes().as_ref(), &key);
             if u8::try_from(tcp).is_ok() {
@@ -1662,7 +1657,7 @@ mod tests {
         let key = k256::ecdsa::SigningKey::random(&mut rand::thread_rng());
 
         for tcp in LOW_INT_PORTS {
-            let mut enr = Enr::empty_v4(&key).unwrap();
+            let mut enr = Enr::empty(&key).unwrap();
 
             let res = enr.remove_insert(
                 [b"none"].iter(),
@@ -1706,7 +1701,7 @@ mod tests {
         let ip = Ipv4Addr::new(10, 0, 0, 1);
         let tcp = 30303;
 
-        let enr1 = Enr::v4_builder().ip4(ip).tcp4(tcp).build(&key).unwrap();
+        let enr1 = Enr::builder().ip4(ip).tcp4(tcp).build(&key).unwrap();
 
         let mut enr2 = enr1.clone();
         enr2.set_seq(1, &key).unwrap();
@@ -1735,7 +1730,7 @@ mod tests {
         // hack an enr object that is too big. This is not possible via the public API.
         let key = k256::ecdsa::SigningKey::random(&mut rand::thread_rng());
 
-        let mut huge_enr = Enr::empty_v4(&key).unwrap();
+        let mut huge_enr = Enr::empty(&key).unwrap();
         let large_vec: Vec<u8> = std::iter::repeat(0).take(MAX_ENR_SIZE).collect();
         let large_vec_encoded = rlp::encode(&large_vec).freeze();
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,7 +57,7 @@
 //! let key = k256::ecdsa::SigningKey::random(&mut rng);
 //!
 //! let ip = Ipv4Addr::new(192,168,0,1);
-//! let enr = Enr::v4_builder().ip4(ip).tcp4(8000).build(&key).unwrap();
+//! let enr = Enr::builder().ip4(ip).tcp4(8000).build(&key).unwrap();
 //!
 //! assert_eq!(enr.ip4(), Some("192.168.0.1".parse().unwrap()));
 //! assert_eq!(enr.id(), Some("v4".into()));
@@ -79,7 +79,7 @@
 //! let key = CombinedKey::generate_ed25519();
 //!
 //! let ip = Ipv4Addr::new(192,168,0,1);
-//! let enr = Enr::v4_builder().ip4(ip).tcp4(8000).build(&key).unwrap();
+//! let enr = Enr::builder().ip4(ip).tcp4(8000).build(&key).unwrap();
 //!
 //! assert_eq!(enr.ip4(), Some("192.168.0.1".parse().unwrap()));
 //! assert_eq!(enr.id(), Some("v4".into()));
@@ -104,7 +104,7 @@
 //! let key = SigningKey::random(&mut rng);
 //!
 //! let ip = Ipv4Addr::new(192,168,0,1);
-//! let mut enr = Enr::v4_builder().ip4(ip).tcp4(8000).build(&key).unwrap();
+//! let mut enr = Enr::builder().ip4(ip).tcp4(8000).build(&key).unwrap();
 //!
 //! enr.set_tcp4(8001, &key);
 //! // set a custom key
@@ -135,14 +135,14 @@
 //! let mut rng = thread_rng();
 //! let key = ecdsa::SigningKey::random(&mut rng);
 //! let ip = Ipv4Addr::new(192,168,0,1);
-//! let enr_secp256k1 = Enr::v4_builder().ip4(ip).tcp4(8000).build(&key).unwrap();
+//! let enr_secp256k1 = Enr::builder().ip4(ip).tcp4(8000).build(&key).unwrap();
 //!
 //! // encode to base64
 //! let base64_string_secp256k1 = enr_secp256k1.to_base64();
 //!
 //! // generate a random ed25519 key
 //! let key = ed25519::SigningKey::generate(&mut rng);
-//! let enr_ed25519 = Enr::v4_builder().ip4(ip).tcp4(8000).build(&key).unwrap();
+//! let enr_ed25519 = Enr::builder().ip4(ip).tcp4(8000).build(&key).unwrap();
 //!
 //! // encode to base64
 //! let base64_string_ed25519 = enr_ed25519.to_base64();
@@ -1355,7 +1355,7 @@ mod tests {
         let ip = Ipv4Addr::new(127, 0, 0, 1);
         let tcp = 3000;
 
-        let enr = Enr::v4_builder().ip4(ip).tcp4(tcp).build(&key).unwrap();
+        let enr = Enr::builder().ip4(ip).tcp4(tcp).build(&key).unwrap();
 
         let encoded_enr = rlp::encode(&enr);
 
@@ -1408,7 +1408,7 @@ mod tests {
         let udp = 30303;
 
         let key = secp256k1::SecretKey::from_slice(&key_data).unwrap();
-        let enr = Enr::v4_builder().ip4(ip).udp4(udp).build(&key).unwrap();
+        let enr = Enr::builder().ip4(ip).udp4(udp).build(&key).unwrap();
         let enr_base64 = enr.to_base64();
         assert_eq!(enr_base64, expected_enr_base64);
 
@@ -1446,7 +1446,7 @@ mod tests {
         let ip = Ipv4Addr::new(10, 0, 0, 1);
         let tcp = 30303;
 
-        let enr = Enr::v4_builder().ip4(ip).tcp4(tcp).build(&key).unwrap();
+        let enr = Enr::builder().ip4(ip).tcp4(tcp).build(&key).unwrap();
 
         let encoded_enr = rlp::encode(&enr);
         let decoded_enr = rlp::decode::<Enr<CombinedKey>>(&encoded_enr).unwrap();
@@ -1522,7 +1522,7 @@ mod tests {
         // generate a random secp256k1 key
         let key = k256::ecdsa::SigningKey::random(&mut rand::thread_rng());
         let ip = Ipv4Addr::new(192, 168, 0, 1);
-        let enr_secp256k1 = Enr::v4_builder()
+        let enr_secp256k1 = Enr::builder()
             .ip(ip.into())
             .tcp4(8000)
             .build(&key)
@@ -1533,7 +1533,7 @@ mod tests {
 
         // generate a random ed25519 key
         let key = ed25519_dalek::SigningKey::generate(&mut rand::thread_rng());
-        let enr_ed25519 = Enr::v4_builder()
+        let enr_ed25519 = Enr::builder()
             .ip(ip.into())
             .tcp4(8000)
             .build(&key)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,12 +43,12 @@
 //!
 //! ## Examples
 //!
-//! To build an ENR, an [`EnrBuilder`] is provided.
+//! To build an ENR, a [`builder::Builder`] is provided.
 //!
 //! ### Building an ENR with the default `k256` `secp256k1` key type
 //!
 //! ```rust
-//! use enr::{EnrBuilder, k256};
+//! use enr::{Enr, k256};
 //! use std::net::Ipv4Addr;
 //! use rand::thread_rng;
 //!
@@ -57,7 +57,7 @@
 //! let key = k256::ecdsa::SigningKey::random(&mut rng);
 //!
 //! let ip = Ipv4Addr::new(192,168,0,1);
-//! let enr = EnrBuilder::new("v4").ip4(ip).tcp4(8000).build(&key).unwrap();
+//! let enr = Enr::v4_builder().ip4(ip).tcp4(8000).build(&key).unwrap();
 //!
 //! assert_eq!(enr.ip4(), Some("192.168.0.1".parse().unwrap()));
 //! assert_eq!(enr.id(), Some("v4".into()));
@@ -66,11 +66,10 @@
 //! ### Building an ENR with the `CombinedKey` type (support for multiple signing
 //! algorithms).
 //!
-//! Note the `ed25519` feature flag must be set. This makes use of the
-//! [`EnrBuilder`] struct.
+//! Note the `ed25519` feature flag must be set.
 //! ```rust
 //! # #[cfg(feature = "ed25519")] {
-//! use enr::{EnrBuilder, CombinedKey};
+//! use enr::{Enr, CombinedKey};
 //! use std::net::Ipv4Addr;
 //!
 //! // create a new secp256k1 key
@@ -80,7 +79,7 @@
 //! let key = CombinedKey::generate_ed25519();
 //!
 //! let ip = Ipv4Addr::new(192,168,0,1);
-//! let enr = EnrBuilder::new("v4").ip4(ip).tcp4(8000).build(&key).unwrap();
+//! let enr = Enr::v4_builder().ip4(ip).tcp4(8000).build(&key).unwrap();
 //!
 //! assert_eq!(enr.ip4(), Some("192.168.0.1".parse().unwrap()));
 //! assert_eq!(enr.id(), Some("v4".into()));
@@ -93,7 +92,7 @@
 //! can be added using [`insert`] and retrieved with [`get`].
 //!
 //! ```rust
-//! use enr::{EnrBuilder, k256::ecdsa::SigningKey, Enr};
+//! use enr::{k256::ecdsa::SigningKey, Enr};
 //! use std::net::Ipv4Addr;
 //! use rand::thread_rng;
 //!
@@ -105,7 +104,7 @@
 //! let key = SigningKey::random(&mut rng);
 //!
 //! let ip = Ipv4Addr::new(192,168,0,1);
-//! let mut enr = EnrBuilder::new("v4").ip4(ip).tcp4(8000).build(&key).unwrap();
+//! let mut enr = Enr::v4_builder().ip4(ip).tcp4(8000).build(&key).unwrap();
 //!
 //! enr.set_tcp4(8001, &key);
 //! // set a custom key
@@ -127,7 +126,7 @@
 //!
 //! ```rust
 //! # #[cfg(feature = "ed25519")] {
-//! use enr::{EnrBuilder, k256::ecdsa, Enr, ed25519_dalek as ed25519, CombinedKey};
+//! use enr::{k256::ecdsa, Enr, ed25519_dalek as ed25519, CombinedKey};
 //! use std::net::Ipv4Addr;
 //! use rand::thread_rng;
 //! use rand::Rng;
@@ -136,14 +135,14 @@
 //! let mut rng = thread_rng();
 //! let key = ecdsa::SigningKey::random(&mut rng);
 //! let ip = Ipv4Addr::new(192,168,0,1);
-//! let enr_secp256k1 = EnrBuilder::new("v4").ip4(ip).tcp4(8000).build(&key).unwrap();
+//! let enr_secp256k1 = Enr::v4_builder().ip4(ip).tcp4(8000).build(&key).unwrap();
 //!
 //! // encode to base64
 //! let base64_string_secp256k1 = enr_secp256k1.to_base64();
 //!
 //! // generate a random ed25519 key
 //! let key = ed25519::SigningKey::generate(&mut rng);
-//! let enr_ed25519 = EnrBuilder::new("v4").ip4(ip).tcp4(8000).build(&key).unwrap();
+//! let enr_ed25519 = Enr::v4_builder().ip4(ip).tcp4(8000).build(&key).unwrap();
 //!
 //! // encode to base64
 //! let base64_string_ed25519 = enr_ed25519.to_base64();
@@ -164,7 +163,6 @@
 //! [`CombinedKey`]: enum.CombinedKey.html
 //! [`EnrKey`]: trait.EnrKey.html
 //! [`Enr`]: struct.Enr.html
-//! [`EnrBuilder`]: struct.EnrBuilder.html
 //! [`NodeId`]: struct.NodeId.html
 //! [`insert`]: struct.Enr.html#method.insert
 //! [`get`]: struct.Enr.html#method.get
@@ -200,7 +198,6 @@ use std::{
     str::FromStr,
 };
 
-pub use builder::EnrBuilder;
 pub use error::EnrError;
 
 #[cfg(feature = "k256")]
@@ -243,6 +240,23 @@ pub struct Enr<K: EnrKey> {
 }
 
 impl<K: EnrKey> Enr<K> {
+    /* Builders */
+
+    /// Get a [`builder::Builder`] with a given identity scheme.
+    pub fn builder(id: impl Into<String>) -> builder::Builder<K> {
+        builder::Builder::new(id)
+    }
+
+    /// Get a [`builder::Builder`] with the default identity scheme
+    pub fn v4_builder() -> builder::Builder<K> {
+        builder::Builder::new_v4()
+    }
+
+    /// Get an empty Enr for the v4 identity scheme.
+    pub fn empty_v4(signing_key: &K) -> Result<Self, EnrError> {
+        Self::v4_builder().build(signing_key)
+    }
+
     // getters //
 
     /// The `NodeId` for the record.
@@ -1332,12 +1346,7 @@ mod tests {
         let ip = Ipv4Addr::new(127, 0, 0, 1);
         let tcp = 3000;
 
-        let enr = {
-            let mut builder = EnrBuilder::new("v4");
-            builder.ip4(ip);
-            builder.tcp4(tcp);
-            builder.build(&key).unwrap()
-        };
+        let enr = Enr::v4_builder().ip4(ip).tcp4(tcp).build(&key).unwrap();
 
         let encoded_enr = rlp::encode(&enr);
 
@@ -1390,7 +1399,7 @@ mod tests {
         let udp = 30303;
 
         let key = secp256k1::SecretKey::from_slice(&key_data).unwrap();
-        let enr = EnrBuilder::new("v4").ip4(ip).udp4(udp).build(&key).unwrap();
+        let enr = Enr::v4_builder().ip4(ip).udp4(udp).build(&key).unwrap();
         let enr_base64 = enr.to_base64();
         assert_eq!(enr_base64, expected_enr_base64);
 
@@ -1405,12 +1414,7 @@ mod tests {
         let ip = Ipv4Addr::new(127, 0, 0, 1);
         let tcp = 3000;
 
-        let enr = {
-            let mut builder = EnrBuilder::new("v4");
-            builder.ip(ip.into());
-            builder.tcp4(tcp);
-            builder.build(&key).unwrap()
-        };
+        let enr = Enr::v4_builder().ip4(ip).tcp4(tcp).build(&key).unwrap();
 
         let encoded_enr = rlp::encode(&enr);
 
@@ -1433,12 +1437,7 @@ mod tests {
         let ip = Ipv4Addr::new(10, 0, 0, 1);
         let tcp = 30303;
 
-        let enr = {
-            let mut builder = EnrBuilder::new("v4");
-            builder.ip4(ip);
-            builder.tcp4(tcp);
-            builder.build(&key).unwrap()
-        };
+        let enr = Enr::v4_builder().ip4(ip).tcp4(tcp).build(&key).unwrap();
 
         let encoded_enr = rlp::encode(&enr);
         let decoded_enr = rlp::decode::<Enr<CombinedKey>>(&encoded_enr).unwrap();
@@ -1457,12 +1456,7 @@ mod tests {
         let ip = Ipv4Addr::new(10, 0, 0, 1);
         let tcp = 30303;
 
-        let mut enr = {
-            let mut builder = EnrBuilder::new("v4");
-            builder.ip(ip.into());
-            builder.tcp4(tcp);
-            builder.build(&key).unwrap()
-        };
+        let mut enr = Enr::v4_builder().ip4(ip).tcp4(tcp).build(&key).unwrap();
 
         enr.insert("random", &Vec::new(), &key).unwrap();
         assert!(enr.verify());
@@ -1475,11 +1469,7 @@ mod tests {
         let tcp = 30303;
         let ip = Ipv4Addr::new(10, 0, 0, 1);
 
-        let mut enr = {
-            let mut builder = EnrBuilder::new("v4");
-            builder.tcp4(tcp);
-            builder.build(&key).unwrap()
-        };
+        let mut enr = Enr::v4_builder().tcp4(tcp).build(&key).unwrap();
 
         assert!(enr.set_ip(ip.into(), &key).is_ok());
         assert_eq!(enr.id(), Some("v4".into()));
@@ -1499,13 +1489,12 @@ mod tests {
         let udp = 30304;
         let ip = Ipv4Addr::new(10, 0, 0, 1);
 
-        let mut enr = {
-            let mut builder = EnrBuilder::new("v4");
-            builder.ip(ip.into());
-            builder.tcp4(tcp);
-            builder.udp4(udp);
-            builder.build(&key).unwrap()
-        };
+        let mut enr = Enr::v4_builder()
+            .ip4(ip)
+            .tcp4(tcp)
+            .udp4(udp)
+            .build(&key)
+            .unwrap();
 
         let node_id = enr.node_id();
 
@@ -1524,7 +1513,7 @@ mod tests {
         // generate a random secp256k1 key
         let key = k256::ecdsa::SigningKey::random(&mut rand::thread_rng());
         let ip = Ipv4Addr::new(192, 168, 0, 1);
-        let enr_secp256k1 = EnrBuilder::new("v4")
+        let enr_secp256k1 = Enr::v4_builder()
             .ip(ip.into())
             .tcp4(8000)
             .build(&key)
@@ -1535,7 +1524,7 @@ mod tests {
 
         // generate a random ed25519 key
         let key = ed25519_dalek::SigningKey::generate(&mut rand::thread_rng());
-        let enr_ed25519 = EnrBuilder::new("v4")
+        let enr_ed25519 = Enr::v4_builder()
             .ip(ip.into())
             .tcp4(8000)
             .build(&key)
@@ -1570,11 +1559,7 @@ mod tests {
         s.append(&"eth_syncing");
         topics.extend_from_slice(&s.out().freeze());
 
-        let mut enr = {
-            let mut builder = EnrBuilder::new("v4");
-            builder.tcp4(tcp);
-            builder.build(&key).unwrap()
-        };
+        let mut enr = Enr::v4_builder().tcp4(tcp).build(&key).unwrap();
 
         assert_eq!(enr.tcp4(), Some(tcp));
         assert_eq!(enr.get("topics"), None);
@@ -1615,11 +1600,7 @@ mod tests {
         let key = k256::ecdsa::SigningKey::random(&mut rand::thread_rng());
 
         for tcp in LOW_INT_PORTS {
-            let enr = {
-                let mut builder = EnrBuilder::new("v4");
-                builder.tcp4(tcp);
-                builder.build(&key).unwrap()
-            };
+            let enr = Enr::v4_builder().tcp4(tcp).build(&key).unwrap();
 
             assert_tcp4(&enr, tcp);
         }
@@ -1630,7 +1611,7 @@ mod tests {
         let key = k256::ecdsa::SigningKey::random(&mut rand::thread_rng());
 
         for tcp in LOW_INT_PORTS {
-            let mut enr = EnrBuilder::new("v4").build(&key).unwrap();
+            let mut enr = Enr::empty_v4(&key).unwrap();
             enr.set_tcp4(tcp, &key).unwrap();
             assert_tcp4(&enr, tcp);
         }
@@ -1642,7 +1623,7 @@ mod tests {
         let ipv4 = Ipv4Addr::new(127, 0, 0, 1);
 
         for tcp in LOW_INT_PORTS {
-            let mut enr = EnrBuilder::new("v4").build(&key).unwrap();
+            let mut enr = Enr::empty_v4(&key).unwrap();
             enr.set_socket(SocketAddr::V4(SocketAddrV4::new(ipv4, tcp)), &key, true)
                 .unwrap();
             assert_tcp4(&enr, tcp);
@@ -1654,7 +1635,7 @@ mod tests {
         let key = k256::ecdsa::SigningKey::random(&mut rand::thread_rng());
 
         for tcp in LOW_INT_PORTS {
-            let mut enr = EnrBuilder::new("v4").build(&key).unwrap();
+            let mut enr = Enr::empty_v4(&key).unwrap();
 
             let res = enr.insert(b"tcp", &tcp.to_be_bytes().as_ref(), &key);
             if u8::try_from(tcp).is_ok() {
@@ -1671,7 +1652,7 @@ mod tests {
         let key = k256::ecdsa::SigningKey::random(&mut rand::thread_rng());
 
         for tcp in LOW_INT_PORTS {
-            let mut enr = EnrBuilder::new("v4").build(&key).unwrap();
+            let mut enr = Enr::empty_v4(&key).unwrap();
 
             let res = enr.remove_insert(
                 vec![b"none"].iter(),
@@ -1715,12 +1696,7 @@ mod tests {
         let ip = Ipv4Addr::new(10, 0, 0, 1);
         let tcp = 30303;
 
-        let enr1 = {
-            let mut builder = EnrBuilder::new("v4");
-            builder.ip4(ip);
-            builder.tcp4(tcp);
-            builder.build(&key).unwrap()
-        };
+        let enr1 = Enr::v4_builder().ip4(ip).tcp4(tcp).build(&key).unwrap();
 
         let mut enr2 = enr1.clone();
         enr2.set_seq(1, &key).unwrap();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -244,7 +244,7 @@ impl<K: EnrKey> Enr<K> {
 
     /// Get a [`builder::Builder`] with the default identity scheme.
     pub fn builder() -> builder::Builder<K> {
-        builder::Builder::new()
+        builder::Builder::default()
     }
 
     /// Get an empty Enr for the v4 identity scheme.
@@ -1522,22 +1522,14 @@ mod tests {
         // generate a random secp256k1 key
         let key = k256::ecdsa::SigningKey::random(&mut rand::thread_rng());
         let ip = Ipv4Addr::new(192, 168, 0, 1);
-        let enr_secp256k1 = Enr::builder()
-            .ip(ip.into())
-            .tcp4(8000)
-            .build(&key)
-            .unwrap();
+        let enr_secp256k1 = Enr::builder().ip(ip.into()).tcp4(8000).build(&key).unwrap();
 
         // encode to base64
         let base64_string_secp256k1 = enr_secp256k1.to_base64();
 
         // generate a random ed25519 key
         let key = ed25519_dalek::SigningKey::generate(&mut rand::thread_rng());
-        let enr_ed25519 = Enr::builder()
-            .ip(ip.into())
-            .tcp4(8000)
-            .build(&key)
-            .unwrap();
+        let enr_ed25519 = Enr::builder().ip(ip.into()).tcp4(8000).build(&key).unwrap();
 
         // encode to base64
         let base64_string_ed25519 = enr_ed25519.to_base64();

--- a/tests/ecdsa/rust_secp256k1.rs
+++ b/tests/ecdsa/rust_secp256k1.rs
@@ -1,4 +1,4 @@
-use enr::{Enr, EnrBuilder};
+use enr::Enr;
 use std::net::Ipv4Addr;
 
 // Ensures the mock data is not used in the production environment.
@@ -13,7 +13,7 @@ fn test_secp256k1_sign_ecdsa_with_noncedata() {
     let udp = 30303;
 
     let key = secp256k1::SecretKey::from_slice(&key_data).unwrap();
-    let enr = EnrBuilder::new("v4").ip4(ip).udp4(udp).build(&key).unwrap();
+    let enr = Enr::v4_builder().ip4(ip).udp4(udp).build(&key).unwrap();
     let enr_base64 = enr.to_base64();
     assert_ne!(enr_base64, not_expected_enr_base64);
 

--- a/tests/ecdsa/rust_secp256k1.rs
+++ b/tests/ecdsa/rust_secp256k1.rs
@@ -13,7 +13,7 @@ fn test_secp256k1_sign_ecdsa_with_noncedata() {
     let udp = 30303;
 
     let key = secp256k1::SecretKey::from_slice(&key_data).unwrap();
-    let enr = Enr::v4_builder().ip4(ip).udp4(udp).build(&key).unwrap();
+    let enr = Enr::builder().ip4(ip).udp4(udp).build(&key).unwrap();
     let enr_base64 = enr.to_base64();
     assert_ne!(enr_base64, not_expected_enr_base64);
 


### PR DESCRIPTION
A couple of improvements for ergonomics
- For an user of the builder, calling `new("v4")` provides little value taking into account `v4` is the only supported identity scheme. So just implement `Default` for the builder instead,
- A more common and friendly pattern is to given access to the `BuilderOfX` via `X::builder` since that's an easily avoidable import, so now `Enr` provides: `Enr::builder()`
- In some cases it's desirable to get an empty `Enr`. This would be `EnrBuilder::new().build(&key)`, there is a friendly shortcut for this `Enr::empty`
- Removes the `Enr` prefix from `EnrBuilder` this shouldn't be even needed to import thanks to the `Enr::builder` and `Enr::empty` 

## Notes
Tests don't use the most ergonomic versions of the builder in their current form (before this change). Since test setup is most of the time done by copying the setup from a related test, I updated them all to use the most appropriate, ergonomic version of what they had

Also, there is a clippy failure but I don't think having those warnings enabled makes sense: 
- #54  