### PR TITLE
Add extension features

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,6 +46,8 @@ jobs:
         run: cargo nextest run --all --release --features "libp2p" --tests
       - name: Run tests in release libp2p, rust-secp256k1
         run: cargo nextest run --all --release --features "libp2p,rust-secp256k1" --tests
+      - name: Run tests in release eth2 
+        run: cargo nextest run --all --release --features "eth2" --tests
       - name: Run tests in release all features
         run: cargo nextest run --all --release --all-features
   check-rustdoc-links:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,45 +10,44 @@ jobs:
   code-check:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - name: Get latest version of stable rust
-      run: rustup update stable
+    - uses: actions/checkout@v3
+    - name: Get latest version of stable Rust
+      uses: moonrepo/setup-rust@v1
+      with:
+          channel: stable
+          cache-target: release
+          components: rustfmt, clippy
+          bins: cargo-audit
     - name: Check formatting with cargofmt
       run: cargo fmt -- --check
     - name: Check for lint warnings
       run: cargo clippy --all-features -- -D warnings
-  release-tests-ubuntu
+    - name: Run cargo audit to identify known security vulnerabilities reported to the RustSec Advisory Database
+      run: cargo audit
+  release-tests-ubuntu:
     runs-on: ubuntu-latest
-    needs: cargo-fmt
     steps:
-      - uses: actions/checkout@v2
-      - name: Get latest version of stable rust
-        run: rustup update stable
+      - uses: actions/checkout@v3
+      - name: Get latest version of stable Rust
+        uses: moonrepo/setup-rust@v1
+        with:
+            channel: stable
+            cache-target: release
+            bins: cargo-nextest
       - name: Run tests in release
-        run: cargo test --all --release --tests
+        run: cargo nextest run --all --release --tests
       - name: Run tests in release ed25519
-        run: cargo test --all --release --features "ed25519" --tests
+        run: cargo nextest run --all --release --features "ed25519" --tests
       - name: Run tests in release secp256k1
-        run: cargo test --all --release --features "secp256k1" --tests
+        run: cargo nextest run --all --release --features "secp256k1" --tests
       - name: Run tests in release rust-secp256k1
-        run: cargo test --all --release --features "rust-secp256k1" --tests
+        run: cargo nextest run --all --release --features "rust-secp256k1" --tests
       - name: Run tests in release libp2p
-        run: cargo test --all --release --features "libp2p" --tests
+        run: cargo nextest run --all --release --features "libp2p" --tests
       - name: Run tests in release libp2p, rust-secp256k1
-        run: cargo test --all --release --features "libp2p,rust-secp256k1" --tests
+        run: cargo nextest run --all --release --features "libp2p,rust-secp256k1" --tests
       - name: Run tests in release all features
-        run: cargo test --all --release --all-features
-  cargo-audit:
-    runs-on: ubuntu-latest
-    needs: cargo-fmt
-    steps:
-      - uses: actions/checkout@v2
-      - name: Get latest version of stable rust
-        run: rustup update stable
-      - name: Get latest cargo audit
-        run: cargo install --force cargo-audit
-      - name: Run cargo audit to identify known security vulnerabilities reported to the RustSec Advisory Database
-        run: cargo audit
+        run: cargo nextest run --all --release --all-features
   check-rustdoc-links:
     name: Check rustdoc intra-doc links
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,7 @@ on:
   pull_request:
 
 jobs:
-  cargo-fmt:
+  code-check:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
@@ -15,15 +15,9 @@ jobs:
       run: rustup update stable
     - name: Check formatting with cargofmt
       run: cargo fmt -- --check
-  cargo-clippy:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v2
-    - name: Get latest version of stable rust
-      run: rustup update stable
     - name: Check for lint warnings
       run: cargo clippy --all-features -- -D warnings
-  release-tests-ubuntu:
+  release-tests-ubuntu
     runs-on: ubuntu-latest
     needs: cargo-fmt
     steps:
@@ -32,24 +26,18 @@ jobs:
         run: rustup update stable
       - name: Run tests in release
         run: cargo test --all --release --tests
-  release-tests-ubuntu-all-features:
-    runs-on: ubuntu-latest
-    needs: cargo-fmt
-    steps:
-      - uses: actions/checkout@v2
-      - name: Get latest version of stable rust
-        run: rustup update stable
-      - name: Run tests in release
-        run: cargo test --all --release --all-features
-  release-tests-ubuntu-ed25519:
-    runs-on: ubuntu-latest
-    needs: cargo-fmt
-    steps:
-      - uses: actions/checkout@v2
-      - name: Get latest version of stable rust
-        run: rustup update stable
-      - name: Run tests in release
+      - name: Run tests in release ed25519
         run: cargo test --all --release --features "ed25519" --tests
+      - name: Run tests in release secp256k1
+        run: cargo test --all --release --features "secp256k1" --tests
+      - name: Run tests in release rust-secp256k1
+        run: cargo test --all --release --features "rust-secp256k1" --tests
+      - name: Run tests in release libp2p
+        run: cargo test --all --release --features "libp2p" --tests
+      - name: Run tests in release libp2p, rust-secp256k1
+        run: cargo test --all --release --features "libp2p,rust-secp256k1" --tests
+      - name: Run tests in release all features
+        run: cargo test --all --release --all-features
   cargo-audit:
     runs-on: ubuntu-latest
     needs: cargo-fmt

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,6 +54,6 @@ jobs:
     container:
       image: rust
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Check rustdoc links
       run: RUSTDOCFLAGS="--deny broken_intra_doc_links" cargo doc --verbose --workspace --no-deps --document-private-items

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,8 @@ secp256k1 = { version = "0.27", optional = true, default-features = false, featu
 ] }
 libp2p-core = { version = "0.40.1", optional = true }
 libp2p-identity = { version = "0.2.3", optional = true, features = ["peerid", "secp256k1", "ed25519"] }
+ssz_types = {version = "0.5.4", optional = true }
+ethereum_ssz = { version = "0.5.3", optional = true }
 
 [dev-dependencies]
 secp256k1 = { features = ["rand-std"], version = "0.27" }
@@ -39,6 +41,7 @@ ed25519 = ["ed25519-dalek"]
 rust-secp256k1 = ["secp256k1"]
 quic = []
 libp2p = ["libp2p-core", "libp2p-identity"]
+eth2 = ["ssz_types", "ethereum_ssz"]
 
 [lib]
 name = "enr"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,8 +26,8 @@ ed25519-dalek = { version = "2.0.0", optional = true, features = ["rand_core"] }
 secp256k1 = { version = "0.27", optional = true, default-features = false, features = [
     "global-context",
 ] }
-libp2p-core = { version = "0.40.1", optional = true }
-libp2p-identity = { version = "0.2.3", optional = true, features = ["peerid", "secp256k1", "ed25519"] }
+libp2p-core = { version = "0.40", optional = true }
+libp2p-identity = { version = "0.2", optional = true, features = ["peerid", "secp256k1", "ed25519"] }
 ssz_types = {version = "0.5.4", optional = true }
 ethereum_ssz = { version = "0.5.3", optional = true }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,8 @@ ed25519-dalek = { version = "2.0.0", optional = true, features = ["rand_core"] }
 secp256k1 = { version = "0.27", optional = true, default-features = false, features = [
     "global-context",
 ] }
+libp2p-core = { version = "0.40.1", optional = true }
+libp2p-identity = { version = "0.2.3", optional = true, features = ["peerid", "secp256k1", "ed25519"] }
 
 [dev-dependencies]
 secp256k1 = { features = ["rand-std"], version = "0.27" }
@@ -35,6 +37,8 @@ serde_json = { version = "1.0.95" }
 default = ["serde", "k256"]
 ed25519 = ["ed25519-dalek"]
 rust-secp256k1 = ["secp256k1"]
+quic = []
+libp2p = ["libp2p-core", "libp2p-identity"]
 
 [lib]
 name = "enr"

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -19,7 +19,7 @@ use std::{
 // Generates function setters on the `EnrBuilder`.
 macro_rules! generate_setter {
     // Function name, variable type and key
-    ($name:ident, $type:ident, $key:ident) => {
+    ($name:ident, $type:ty, $key:ident) => {
         #[doc = concat!(" Adds a `", stringify!($name),"` field to the `ENRBuilder.")]
         pub fn $name(&mut self, var: $type) -> &mut Self {
             self.add_value($key, &var);
@@ -105,23 +105,13 @@ impl<K: EnrKey> EnrBuilder<K> {
     #[cfg(feature = "eth2")]
     generate_setter!(eth2, &[u8], ETH2_ENR_KEY);
     #[cfg(feature = "eth2")]
-    /// Adds an 'attestation_bitfield` field to the `ENRBuilder`.  
-    pub fn attestation_bitfield(&mut self, attestation_bitfield: BitVector<N>) -> &mut Self {
-        self.add_value(
-            ATTESTATION_BITFIELD_ENR_KEY,
-            attestation_bitfield.to_bytes(),
-        );
-        self
-    }
+    generate_setter!(attestation_bitfield, &[u8], ATTESTATION_BITFIELD_ENR_KEY);
     #[cfg(feature = "eth2")]
-    /// Adds an 'attestation_bitfield` field to the `ENRBuilder`.  
-    pub fn sync_committee_bitfield(&mut self, sync_committee_bitfield: BitVector<N>) -> &mut Self {
-        self.add_value(
-            SYNC_COMMITTEE_BITFIELD_ENR_KEY,
-            sync_committee_bitfield.to_bytes(),
-        );
-        self
-    }
+    generate_setter!(
+        sync_committee_bitfield,
+        &[u8],
+        SYNC_COMMITTEE_BITFIELD_ENR_KEY
+    );
 
     /// Generates the rlp-encoded form of the ENR specified by the builder config.
     fn rlp_content(&self) -> BytesMut {

--- a/src/keys/ed25519.rs
+++ b/src/keys/ed25519.rs
@@ -7,6 +7,9 @@ use bytes::Bytes;
 use rlp::DecoderError;
 use std::{collections::BTreeMap, convert::TryFrom};
 
+#[cfg(feature = "libp2p")]
+use libp2p_identity::{ed25519 as libp2p_ed25519, PeerId, PublicKey};
+
 /// The ENR key that stores the public key in the ENR record.
 pub const ENR_KEY: &str = "ed25519";
 
@@ -71,5 +74,17 @@ impl EnrPublicKey for ed25519::VerifyingKey {
     /// Generates the ENR public key string associated with the ed25519 key type.
     fn enr_key(&self) -> Key {
         ENR_KEY.into()
+    }
+
+    /// Converts the publickey into a peer id, without consuming the key.
+    ///
+    /// This is only available with the `libp2p` feature flag.
+    #[cfg(feature = "libp2p")]
+    fn as_peer_id(&self) -> PeerId {
+        let pk_bytes = self.to_bytes();
+        let libp2p_pk: PublicKey = libp2p_ed25519::PublicKey::try_from_bytes(&pk_bytes)
+            .expect("valid public key")
+            .into();
+        PeerId::from_public_key(&libp2p_pk)
     }
 }

--- a/src/keys/k256_key.rs
+++ b/src/keys/k256_key.rs
@@ -20,6 +20,9 @@ use rlp::DecoderError;
 use sha3::{Digest, Keccak256};
 use std::{collections::BTreeMap, convert::TryFrom};
 
+#[cfg(feature = "libp2p")]
+use libp2p_identity::{secp256k1, PeerId, PublicKey};
+
 /// The ENR key that stores the public key in the ENR record.
 pub const ENR_KEY: &str = "secp256k1";
 
@@ -98,6 +101,15 @@ impl EnrPublicKey for VerifyingKey {
         coords[32..].copy_from_slice(&y);
 
         coords
+    }
+
+    #[cfg(feature = "libp2p")]
+    fn as_peer_id(&self) -> PeerId {
+        let pk_bytes = self.to_sec1_bytes();
+        let libp2p_pk: PublicKey = secp256k1::PublicKey::try_from_bytes(&pk_bytes)
+            .expect("valid public key")
+            .into();
+        PeerId::from_public_key(&libp2p_pk)
     }
 
     fn enr_key(&self) -> Key {

--- a/src/keys/mod.rs
+++ b/src/keys/mod.rs
@@ -78,7 +78,7 @@ pub trait EnrPublicKey: Clone + Debug + Send + Sync + Unpin + 'static {
     /// is `secp256k1`.
     fn enr_key(&self) -> Key;
 
-    /// Converts the PublicKey into a peer id, without consuming the key.
+    /// Converts the `PublicKey` into a peer id, without consuming the key.
     ///
     /// This is only available with the `libp2p` feature flag.
     #[cfg(feature = "libp2p")]

--- a/src/keys/mod.rs
+++ b/src/keys/mod.rs
@@ -20,6 +20,8 @@ pub use combined::{CombinedKey, CombinedPublicKey};
 pub use ed25519_dalek;
 #[cfg(feature = "k256")]
 pub use k256;
+#[cfg(feature = "libp2p")]
+use libp2p_identity::PeerId;
 #[cfg(feature = "rust-secp256k1")]
 pub use secp256k1;
 
@@ -75,6 +77,12 @@ pub trait EnrPublicKey: Clone + Debug + Send + Sync + Unpin + 'static {
     /// Returns the ENR key identifier for the public key type. For `secp256k1` keys this
     /// is `secp256k1`.
     fn enr_key(&self) -> Key;
+
+    /// Converts the PublicKey into a peer id, without consuming the key.
+    ///
+    /// This is only available with the `libp2p` feature flag.
+    #[cfg(feature = "libp2p")]
+    fn as_peer_id(&self) -> PeerId;
 }
 
 /// An error during signing of a message.

--- a/src/keys/rust_secp256k1.rs
+++ b/src/keys/rust_secp256k1.rs
@@ -6,6 +6,9 @@ use rlp::DecoderError;
 use secp256k1::SECP256K1;
 use std::collections::BTreeMap;
 
+#[cfg(feature = "libp2p")]
+use libp2p_identity::{secp256k1 as libp2p_secp256k1, PeerId, PublicKey};
+
 #[cfg(test)]
 use self::MockOsRng as OsRng;
 #[cfg(not(test))]
@@ -80,6 +83,15 @@ impl EnrPublicKey for secp256k1::PublicKey {
 
     fn enr_key(&self) -> Key {
         ENR_KEY.into()
+    }
+
+    #[cfg(feature = "libp2p")]
+    fn as_peer_id(&self) -> PeerId {
+        let pk_bytes = self.serialize();
+        let libp2p_pk: PublicKey = libp2p_secp256k1::PublicKey::try_from_bytes(&pk_bytes)
+            .expect("valid public key")
+            .into();
+        PeerId::from_public_key(&libp2p_pk)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1019,6 +1019,17 @@ impl<K: EnrKey> Enr<K> {
     pub fn quic4(&self) -> Option<u16> {
         self.get_decodable(QUIC_ENR_KEY).and_then(Result::ok)
     }
+
+    /// Sets the `quic` field of the ENR. Returns any pre-existing quic port in the record.
+    #[cfg(feature = "quic")]
+    #[must_use]
+    pub fn set_quic4(&mut self, quic: u16, key: &K) -> Result<Option<u16>, EnrError> {
+        if let Some(quic_bytes) = self.insert(QUIC_ENR_KEY, &quic, key)? {
+            return Ok(rlp::decode(&quic_bytes).ok());
+        }
+        Ok(None)
+    }
+
     /// Returns the quic6 port if one is set.
     #[cfg(feature = "quic")]
     #[must_use]
@@ -1026,36 +1037,67 @@ impl<K: EnrKey> Enr<K> {
         self.get_decodable(QUIC6_ENR_KEY).and_then(Result::ok)
     }
 
+    /// Sets the `quic6` field of the ENR. Returns any pre-existing quic6 port in the record.
+    #[cfg(feature = "quic6")]
+    #[must_use]
+    pub fn set_quic6(&mut self, quic6: u16, key: &K) -> Result<Option<u16>, EnrError> {
+        if let Some(quic_bytes) = self.insert(QUIC6_ENR_KEY, &quic6, key)? {
+            return Ok(rlp::decode(&quic_bytes).ok());
+        }
+        Ok(None)
+    }
+
     /// The attestation subnet bitfield associated with the ENR.
     #[cfg(feature = "eth2")]
-    pub fn attestation_bitfield<N: Clone + Unsigned>(&self) -> Result<BitVector<N>, &'static str> {
-        let bitfield_bytes = self
-            .get(ATTESTATION_BITFIELD_ENR_KEY)
-            .ok_or("ENR attestation bitfield non-existent")?;
+    pub fn attestation_bitfield(&self) -> Option<Vec<u8>> {
+        self.get(ATTESTATION_BITFIELD_ENR_KEY)
+    }
 
-        BitVector::<N>::from_ssz_bytes(bitfield_bytes)
-            .map_err(|_| "Could not decode the ENR attnets bitfield")
+    /// Sets the attestation subnet bitfield associated with the ENR.
+    #[cfg(feature = "eth2")]
+    pub fn set_attestation_bitfield(
+        &mut self,
+        bitfield: &[u8],
+        key: &K,
+    ) -> Result<Option<Vec<u8>>, EnrError> {
+        if let Some(bitfield_bytes) = self.insert(ATTESTATION_BITFIELD_ENR_KEY, bitfield, key)? {
+            return Ok(rlp::decode(&bitfield_bytes).ok());
+        }
+        Ok(None)
     }
 
     /// The sync committee subnet bitfield associated with the ENR.
     #[cfg(feature = "eth2")]
-    pub fn sync_committee_bitfield<N: Clone + Unsigned>(
-        &self,
-    ) -> Result<BitVector<N>, &'static str> {
-        let bitfield_bytes = self
-            .get(SYNC_COMMITTEE_BITFIELD_ENR_KEY)
-            .ok_or("ENR sync committee bitfield non-existent")?;
+    pub fn sync_committee_bitfield(&self) -> Option<Vec<u8>> {
+        self.get(SYNC_COMMITTEE_BITFIELD_ENR_KEY)
+    }
 
-        BitVector::<N>::from_ssz_bytes(bitfield_bytes)
-            .map_err(|_| "Could not decode the ENR syncnets bitfield")
+    /// Sets the sync committee bitfield associated with the ENR.
+    #[cfg(feature = "eth2")]
+    pub fn set_sync_committee_bitfield(
+        &mut self,
+        bitfield: &[u8],
+        key: &K,
+    ) -> Result<Option<Vec<u8>>, EnrError> {
+        if let Some(bitfield_bytes) = self.insert(SYNC_COMMITTEE_BITFIELD_ENR_KEY, bitfield, key)? {
+            return Ok(rlp::decode(&bitfield_bytes).ok());
+        }
+        Ok(None)
     }
 
     /// Returns the field that represents an `ENRForkId`. Users must make the type conversion externally.
     #[cfg(feature = "eth2")]
-    pub fn eth2(&self) -> Result<Vec<u8>, &'static str> {
-        self.get(ETH2_ENR_KEY)
-            .map(<[u8]>::to_vec)
-            .ok_or("ENR has no eth2 field")
+    pub fn eth2(&self) -> Option<Vec<u8>> {
+        self.get(ETH2_ENR_KEY).map(<[u8]>::to_vec)
+    }
+
+    /// Sets the eth2 field associated with the ENR.
+    #[cfg(feature = "eth2")]
+    pub fn set_eth2(&mut self, eth2: &[u8], key: &K) -> Result<Option<Vec<u8>>, EnrError> {
+        if let Some(eth2_bytes) = self.insert(ETH2_ENR_KEY, bitfield, key)? {
+            return Ok(rlp::decode(&eth2_bytes).ok());
+        }
+        Ok(None)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1693,7 +1693,7 @@ mod tests {
         let tcp = 3000;
 
         let enr = {
-            let mut builder = EnrBuilder::new("v4");
+            let mut builder = EnrBuilder::new();
             builder.ip(ip.into());
             builder.tcp4(tcp);
             builder.build(&key).unwrap()
@@ -1745,7 +1745,7 @@ mod tests {
         let tcp = 30303;
 
         let mut enr = {
-            let mut builder = EnrBuilder::new("v4");
+            let mut builder = EnrBuilder::new();
             builder.ip(ip.into());
             builder.tcp4(tcp);
             builder.build(&key).unwrap()
@@ -1763,7 +1763,7 @@ mod tests {
         let ip = Ipv4Addr::new(10, 0, 0, 1);
 
         let mut enr = {
-            let mut builder = EnrBuilder::new("v4");
+            let mut builder = EnrBuilder::new();
             builder.tcp4(tcp);
             builder.build(&key).unwrap()
         };
@@ -1787,7 +1787,7 @@ mod tests {
         let ip = Ipv4Addr::new(10, 0, 0, 1);
 
         let mut enr = {
-            let mut builder = EnrBuilder::new("v4");
+            let mut builder = EnrBuilder::new();
             builder.ip(ip.into());
             builder.tcp4(tcp);
             builder.udp4(udp);
@@ -1860,7 +1860,7 @@ mod tests {
         topics.extend_from_slice(&s.out().freeze());
 
         let mut enr = {
-            let mut builder = EnrBuilder::new("v4");
+            let mut builder = EnrBuilder::new();
             builder.tcp4(tcp);
             builder.build(&key).unwrap()
         };
@@ -1905,7 +1905,7 @@ mod tests {
 
         for tcp in LOW_INT_PORTS {
             let enr = {
-                let mut builder = EnrBuilder::new("v4");
+                let mut builder = EnrBuilder::new();
                 builder.tcp4(tcp);
                 builder.build(&key).unwrap()
             };
@@ -1919,7 +1919,7 @@ mod tests {
         let key = k256::ecdsa::SigningKey::random(&mut rand::thread_rng());
 
         for tcp in LOW_INT_PORTS {
-            let mut enr = EnrBuilder::new("v4").build(&key).unwrap();
+            let mut enr = EnrBuilder::new().build(&key).unwrap();
             enr.set_tcp4(tcp, &key).unwrap();
             assert_tcp4(&enr, tcp);
         }
@@ -1931,7 +1931,7 @@ mod tests {
         let ipv4 = Ipv4Addr::new(127, 0, 0, 1);
 
         for tcp in LOW_INT_PORTS {
-            let mut enr = EnrBuilder::new("v4").build(&key).unwrap();
+            let mut enr = EnrBuilder::new().build(&key).unwrap();
             enr.set_socket(SocketAddr::V4(SocketAddrV4::new(ipv4, tcp)), &key, true)
                 .unwrap();
             assert_tcp4(&enr, tcp);
@@ -1943,7 +1943,7 @@ mod tests {
         let key = k256::ecdsa::SigningKey::random(&mut rand::thread_rng());
 
         for tcp in LOW_INT_PORTS {
-            let mut enr = EnrBuilder::new("v4").build(&key).unwrap();
+            let mut enr = EnrBuilder::new().build(&key).unwrap();
 
             println!("Inserting: {}", tcp);
             let res = enr.insert(b"tcp", &tcp.to_be_bytes().as_ref(), &key);
@@ -1961,7 +1961,7 @@ mod tests {
         let key = k256::ecdsa::SigningKey::random(&mut rand::thread_rng());
 
         for tcp in LOW_INT_PORTS {
-            let mut enr = EnrBuilder::new("v4").build(&key).unwrap();
+            let mut enr = EnrBuilder::new().build(&key).unwrap();
 
             println!("Inserting: {}", tcp);
             let res = enr.remove_insert(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -833,6 +833,7 @@ impl<K: EnrKey> Enr<K> {
     // Libp2p features
     /// The libp2p `PeerId` for the record.
     #[cfg(feature = "libp2p")]
+    #[must_use]
     pub fn peer_id(&self) -> PeerId {
         self.public_key().as_peer_id()
     }
@@ -840,6 +841,7 @@ impl<K: EnrKey> Enr<K> {
     /// Returns a list of multiaddrs if the ENR has an `ip` and either a `tcp`, `quic` or `udp` key **or** an `ip6` and either a `tcp6` `quic6` or `udp6`.
     /// The vector remains empty if these fields are not defined.
     #[cfg(feature = "libp2p")]
+    #[must_use]
     pub fn multiaddr(&self) -> Vec<Multiaddr> {
         let mut multiaddrs: Vec<Multiaddr> = Vec::new();
         if let Some(ip) = self.ip4() {
@@ -888,6 +890,7 @@ impl<K: EnrKey> Enr<K> {
 
     /// Returns a list of multiaddrs with the `PeerId` prepended.
     #[cfg(feature = "libp2p")]
+    #[must_use]
     pub fn multiaddr_p2p(&self) -> Vec<Multiaddr> {
         let peer_id = self.peer_id();
         self.multiaddr()
@@ -901,6 +904,7 @@ impl<K: EnrKey> Enr<K> {
 
     /// Returns any multiaddrs that contain the TCP protocol with the `PeerId` prepended.
     #[cfg(feature = "libp2p")]
+    #[must_use]
     pub fn multiaddr_p2p_tcp(&self) -> Vec<Multiaddr> {
         let peer_id = self.peer_id();
         self.multiaddr_tcp()
@@ -914,6 +918,7 @@ impl<K: EnrKey> Enr<K> {
 
     /// Returns any multiaddrs that contain the UDP protocol with the `PeerId` prepended.
     #[cfg(feature = "libp2p")]
+    #[must_use]
     pub fn multiaddr_p2p_udp(&self) -> Vec<Multiaddr> {
         let peer_id = self.peer_id();
         self.multiaddr_udp()
@@ -928,6 +933,7 @@ impl<K: EnrKey> Enr<K> {
     /// Returns any multiaddrs that contain the TCP protocol.
     /// Returns a list of multiaddrs if the ENR has an `ip` and a `tcp` key **or** an `ip6` and a `tcp6` field.
     #[cfg(feature = "libp2p")]
+    #[must_use]
     pub fn multiaddr_tcp(&self) -> Vec<Multiaddr> {
         let mut multiaddrs: Vec<Multiaddr> = Vec::new();
         if let Some(ip) = self.ip4() {
@@ -949,6 +955,7 @@ impl<K: EnrKey> Enr<K> {
 
     /// Returns a list of multiaddrs if the ENR has an `ip` and a `udp` key **or** an `ip6` and a `udp6` field.
     #[cfg(feature = "libp2p")]
+    #[must_use]
     pub fn multiaddr_udp(&self) -> Vec<Multiaddr> {
         let mut multiaddrs: Vec<Multiaddr> = Vec::new();
         if let Some(ip) = self.ip4() {
@@ -970,6 +977,7 @@ impl<K: EnrKey> Enr<K> {
 
     /// Returns a list of multiaddrs if the ENR has an `ip` and a `quic` key **or** an `ip6` and a `quic6`.
     #[cfg(all(feature = "libp2p", feature = "quic"))]
+    #[must_use]
     pub fn multiaddr_quic(&self) -> Vec<Multiaddr> {
         let mut multiaddrs: Vec<Multiaddr> = Vec::new();
         if let Some(quic_port) = self.quic4() {
@@ -994,11 +1002,13 @@ impl<K: EnrKey> Enr<K> {
 
     /// Returns the quic port if one is set.
     #[cfg(feature = "quic")]
+    #[must_use]
     pub fn quic4(&self) -> Option<u16> {
         self.get_decodable(QUIC_ENR_KEY).and_then(Result::ok)
     }
     /// Returns the quic6 port if one is set.
     #[cfg(feature = "quic")]
+    #[must_use]
     pub fn quic6(&self) -> Option<u16> {
         self.get_decodable(QUIC6_ENR_KEY).and_then(Result::ok)
     }


### PR DESCRIPTION
This PR adds extended features to the ENR gated behind feature flags. 

The extra features are:
- libp2p - Enables support for peer-id and multiaddrs from ENRs
- quic - Enables support for extended quic fields
- eth2 - Enables support for Ethereum based consensus fields (not implemented right now)
