### PR TITLE
make error uniform and fix spec-reserved key assertion

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -148,10 +148,8 @@ impl<K: EnrKey> Builder<K> {
         }
 
         // Sanitize all data, ensuring all RLP data is correctly formatted.
-        for (key, value) in &self.content {
-            if rlp::Rlp::new(value).data().is_err() {
-                return Err(Error::InvalidRlpData(String::from_utf8_lossy(key).into()));
-            }
+        for value in self.content.values() {
+            rlp::Rlp::new(value).data()?;
         }
 
         self.add_value_rlp("id", rlp::encode(&self.id.as_bytes()).freeze());

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -1,4 +1,4 @@
-use crate::{Enr, EnrError, EnrKey, EnrPublicKey, Key, NodeId, MAX_ENR_SIZE};
+use crate::{Enr, EnrKey, EnrPublicKey, Error, Key, NodeId, MAX_ENR_SIZE};
 use bytes::{Bytes, BytesMut};
 use rlp::{Encodable, RlpStream};
 use std::{
@@ -122,13 +122,13 @@ impl<K: EnrKey> Builder<K> {
     }
 
     /// Signs record based on the identity scheme. Currently only "v4" is supported.
-    fn signature(&self, key: &K) -> Result<Vec<u8>, EnrError> {
+    fn signature(&self, key: &K) -> Result<Vec<u8>, Error> {
         match self.id.as_str() {
             "v4" => key
                 .sign_v4(&self.rlp_content())
-                .map_err(|_| EnrError::SigningError),
+                .map_err(|_| Error::SigningError),
             // unsupported identity schemes
-            _ => Err(EnrError::SigningError),
+            _ => Err(Error::SigningError),
         }
     }
 
@@ -141,18 +141,16 @@ impl<K: EnrKey> Builder<K> {
     ///
     /// # Errors
     /// Fails if the identity scheme is not supported, or the record size exceeds `MAX_ENR_SIZE`.
-    pub fn build(&mut self, key: &K) -> Result<Enr<K>, EnrError> {
+    pub fn build(&mut self, key: &K) -> Result<Enr<K>, Error> {
         // add the identity scheme to the content
         if self.id != "v4" {
-            return Err(EnrError::UnsupportedIdentityScheme);
+            return Err(Error::UnsupportedIdentityScheme);
         }
 
         // Sanitize all data, ensuring all RLP data is correctly formatted.
         for (key, value) in &self.content {
             if rlp::Rlp::new(value).data().is_err() {
-                return Err(EnrError::InvalidRlpData(
-                    String::from_utf8_lossy(key).into(),
-                ));
+                return Err(Error::InvalidRlpData(String::from_utf8_lossy(key).into()));
             }
         }
 
@@ -165,7 +163,7 @@ impl<K: EnrKey> Builder<K> {
 
         // check the size of the record
         if rlp_content.len() + signature.len() + 8 > MAX_ENR_SIZE {
-            return Err(EnrError::ExceedsMaxSize);
+            return Err(Error::ExceedsMaxSize);
         }
 
         Ok(Enr {

--- a/src/error.rs
+++ b/src/error.rs
@@ -17,6 +17,12 @@ pub enum Error {
     InvalidRlpData(String),
 }
 
+impl From<rlp::DecoderError> for Error {
+    fn from(decode_error: rlp::DecoderError) -> Self {
+        Error::InvalidRlpData(decode_error.to_string())
+    }
+}
+
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {

--- a/src/error.rs
+++ b/src/error.rs
@@ -13,13 +13,13 @@ pub enum Error {
     SigningError,
     /// The identity scheme is not supported.
     UnsupportedIdentityScheme,
-    /// The entered RLP data is invalid.
-    InvalidRlpData(String),
+    /// Failed decoding the RLP data.
+    InvalidRlpData(rlp::DecoderError),
 }
 
 impl From<rlp::DecoderError> for Error {
     fn from(decode_error: rlp::DecoderError) -> Self {
-        Error::InvalidRlpData(decode_error.to_string())
+        Error::InvalidRlpData(decode_error)
     }
 }
 
@@ -35,4 +35,14 @@ impl fmt::Display for Error {
     }
 }
 
-impl std::error::Error for Error {}
+// impl std::error::Error for Error {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Error::ExceedsMaxSize
+            | Error::SequenceNumberTooHigh
+            | Error::SigningError
+            | Error::UnsupportedIdentityScheme => None,
+            Error::InvalidRlpData(e) => Some(e),
+        }
+    }
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,11 +1,10 @@
 //! The error type emitted for various ENR operations.
 
-use std::error::Error;
 use std::fmt;
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 /// An error type for handling various ENR operations.
-pub enum EnrError {
+pub enum Error {
     /// The ENR is too large.
     ExceedsMaxSize,
     /// The sequence number is too large.
@@ -18,7 +17,7 @@ pub enum EnrError {
     InvalidRlpData(String),
 }
 
-impl fmt::Display for EnrError {
+impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::ExceedsMaxSize => write!(f, "enr exceeds max size"),
@@ -30,4 +29,4 @@ impl fmt::Display for EnrError {
     }
 }
 
-impl Error for EnrError {}
+impl std::error::Error for Error {}

--- a/src/error.rs
+++ b/src/error.rs
@@ -35,7 +35,7 @@ impl fmt::Display for Error {
     }
 }
 
-// impl std::error::Error for Error {
+impl std::error::Error for Error {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         match self {
             Error::ExceedsMaxSize

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -742,7 +742,7 @@ impl<K: EnrKey> Enr<K> {
             let value = rlp::encode(&(value)).freeze();
             // Prevent inserting invalid RLP integers
             if is_keyof_u16(key.as_ref()) {
-                rlp::decode::<u16>(&value).map_err(|err| Error::InvalidRlpData(err.to_string()))?;
+                rlp::decode::<u16>(&value)?;
             }
 
             inserted.push(self.content.insert(key.as_ref().to_vec(), value));
@@ -1076,32 +1076,25 @@ const fn is_keyof_u16(key: &[u8]) -> bool {
 fn check_spec_reserved_keys(key: &[u8], value: &[u8]) -> Result<(), Error> {
     match key {
         b"tcp" | b"tcp6" | b"udp" | b"udp6" => {
-            rlp::decode::<u16>(value).map_err(|err| Error::InvalidRlpData(err.to_string()))?;
+            rlp::decode::<u16>(value)?;
         }
         b"id" => {
-            let id_bytes = rlp::decode::<Vec<u8>>(value)
-                .map_err(|err| Error::InvalidRlpData(err.to_string()))?;
+            let id_bytes = rlp::decode::<Vec<u8>>(value)?;
             if id_bytes != b"v4" {
                 return Err(Error::UnsupportedIdentityScheme);
             }
         }
         b"ip" => {
-            let ip4_bytes = rlp::decode::<Vec<u8>>(value)
-                .map_err(|err| Error::InvalidRlpData(err.to_string()))?;
+            let ip4_bytes = rlp::decode::<Vec<u8>>(value)?;
             if ip4_bytes.len() != 4 {
                 return Err(Error::InvalidRlpData("Invalid Ipv4 size".to_string()));
             }
         }
         b"ip6" => {
-            let ip6_bytes = rlp::decode::<Vec<u8>>(value)
-                .map_err(|err| Error::InvalidRlpData(err.to_string()))?;
+            let ip6_bytes = rlp::decode::<Vec<u8>>(value)?;
             if ip6_bytes.len() != 16 {
                 return Err(Error::InvalidRlpData("Invalid Ipv6 size".to_string()));
             }
-        }
-        b"secp256k1" => {
-            rlp::decode::<Enr<k256::ecdsa::SigningKey>>(value)
-                .map_err(|err| Error::InvalidRlpData(err.to_string()))?;
         }
         _ => return Ok(()),
     };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -191,14 +191,14 @@ use std::{
 
 use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine as _};
 #[cfg(feature = "serde")]
-use serde::{de::Error, Deserialize, Deserializer, Serialize, Serializer};
+use serde::{de::Error as _, Deserialize, Deserializer, Serialize, Serializer};
 use sha3::{Digest, Keccak256};
 use std::{
     net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr},
     str::FromStr,
 };
 
-pub use error::EnrError;
+pub use error::Error;
 
 #[cfg(feature = "k256")]
 pub use keys::k256;
@@ -248,7 +248,7 @@ impl<K: EnrKey> Enr<K> {
     }
 
     /// Get an empty Enr for the v4 identity scheme.
-    pub fn empty(signing_key: &K) -> Result<Self, EnrError> {
+    pub fn empty(signing_key: &K) -> Result<Self, Error> {
         Self::builder().build(signing_key)
     }
 
@@ -452,7 +452,7 @@ impl<K: EnrKey> Enr<K> {
     // Setters //
 
     /// Allows setting the sequence number to an arbitrary value.
-    pub fn set_seq(&mut self, seq: u64, key: &K) -> Result<(), EnrError> {
+    pub fn set_seq(&mut self, seq: u64, key: &K) -> Result<(), Error> {
         let prev_seq = self.seq;
         self.seq = seq;
 
@@ -469,7 +469,7 @@ impl<K: EnrKey> Enr<K> {
         if self.size() > MAX_ENR_SIZE {
             self.seq = prev_seq;
             self.signature = prev_signature;
-            return Err(EnrError::ExceedsMaxSize);
+            return Err(Error::ExceedsMaxSize);
         }
 
         // update the node id
@@ -487,7 +487,7 @@ impl<K: EnrKey> Enr<K> {
         key: impl AsRef<[u8]>,
         value: &T,
         enr_key: &K,
-    ) -> Result<Option<Bytes>, EnrError> {
+    ) -> Result<Option<Bytes>, Error> {
         self.insert_raw_rlp(key, rlp::encode(value).freeze(), enr_key)
     }
 
@@ -500,7 +500,7 @@ impl<K: EnrKey> Enr<K> {
         key: impl AsRef<[u8]>,
         value: Bytes,
         enr_key: &K,
-    ) -> Result<Option<Bytes>, EnrError> {
+    ) -> Result<Option<Bytes>, Error> {
         check_spec_reserved_keys(key.as_ref(), &value)?;
 
         let previous_value = self.content.insert(key.as_ref().to_vec(), value);
@@ -526,13 +526,13 @@ impl<K: EnrKey> Enr<K> {
             } else {
                 self.content.remove(key.as_ref());
             }
-            return Err(EnrError::ExceedsMaxSize);
+            return Err(Error::ExceedsMaxSize);
         }
         // increment the sequence number
         self.seq = self
             .seq
             .checked_add(1)
-            .ok_or(EnrError::SequenceNumberTooHigh)?;
+            .ok_or(Error::SequenceNumberTooHigh)?;
 
         // sign the record
         self.sign(enr_key)?;
@@ -542,14 +542,14 @@ impl<K: EnrKey> Enr<K> {
 
         if self.size() > MAX_ENR_SIZE {
             // in case the signature size changes, inform the user the size has exceeded the maximum
-            return Err(EnrError::ExceedsMaxSize);
+            return Err(Error::ExceedsMaxSize);
         }
 
         Ok(previous_value)
     }
 
     /// Sets the `ip` field of the ENR. Returns any pre-existing IP address in the record.
-    pub fn set_ip(&mut self, ip: IpAddr, key: &K) -> Result<Option<IpAddr>, EnrError> {
+    pub fn set_ip(&mut self, ip: IpAddr, key: &K) -> Result<Option<IpAddr>, Error> {
         match ip {
             IpAddr::V4(addr) => {
                 let prev_value = self.insert("ip", &addr.octets().as_ref(), key)?;
@@ -577,7 +577,7 @@ impl<K: EnrKey> Enr<K> {
     }
 
     /// Sets the `udp` field of the ENR. Returns any pre-existing UDP port in the record.
-    pub fn set_udp4(&mut self, udp: u16, key: &K) -> Result<Option<u16>, EnrError> {
+    pub fn set_udp4(&mut self, udp: u16, key: &K) -> Result<Option<u16>, Error> {
         if let Some(udp_bytes) = self.insert("udp", &udp, key)? {
             return Ok(rlp::decode(&udp_bytes).ok());
         }
@@ -585,7 +585,7 @@ impl<K: EnrKey> Enr<K> {
     }
 
     /// Sets the `udp6` field of the ENR. Returns any pre-existing UDP port in the record.
-    pub fn set_udp6(&mut self, udp: u16, key: &K) -> Result<Option<u16>, EnrError> {
+    pub fn set_udp6(&mut self, udp: u16, key: &K) -> Result<Option<u16>, Error> {
         if let Some(udp_bytes) = self.insert("udp6", &udp, key)? {
             return Ok(rlp::decode(&udp_bytes).ok());
         }
@@ -593,7 +593,7 @@ impl<K: EnrKey> Enr<K> {
     }
 
     /// Sets the `tcp` field of the ENR. Returns any pre-existing tcp port in the record.
-    pub fn set_tcp4(&mut self, tcp: u16, key: &K) -> Result<Option<u16>, EnrError> {
+    pub fn set_tcp4(&mut self, tcp: u16, key: &K) -> Result<Option<u16>, Error> {
         if let Some(tcp_bytes) = self.insert("tcp", &tcp, key)? {
             return Ok(rlp::decode(&tcp_bytes).ok());
         }
@@ -601,7 +601,7 @@ impl<K: EnrKey> Enr<K> {
     }
 
     /// Sets the `tcp6` field of the ENR. Returns any pre-existing tcp6 port in the record.
-    pub fn set_tcp6(&mut self, tcp: u16, key: &K) -> Result<Option<u16>, EnrError> {
+    pub fn set_tcp6(&mut self, tcp: u16, key: &K) -> Result<Option<u16>, Error> {
         if let Some(tcp_bytes) = self.insert("tcp6", &tcp, key)? {
             return Ok(rlp::decode(&tcp_bytes).ok());
         }
@@ -609,17 +609,17 @@ impl<K: EnrKey> Enr<K> {
     }
 
     /// Sets the IP and UDP port in a single update with a single increment in sequence number.
-    pub fn set_udp_socket(&mut self, socket: SocketAddr, key: &K) -> Result<(), EnrError> {
+    pub fn set_udp_socket(&mut self, socket: SocketAddr, key: &K) -> Result<(), Error> {
         self.set_socket(socket, key, false)
     }
 
     /// Sets the IP and TCP port in a single update with a single increment in sequence number.
-    pub fn set_tcp_socket(&mut self, socket: SocketAddr, key: &K) -> Result<(), EnrError> {
+    pub fn set_tcp_socket(&mut self, socket: SocketAddr, key: &K) -> Result<(), Error> {
         self.set_socket(socket, key, true)
     }
 
     /// Helper function for `set_tcp_socket()` and `set_udp_socket`.
-    fn set_socket(&mut self, socket: SocketAddr, key: &K, is_tcp: bool) -> Result<(), EnrError> {
+    fn set_socket(&mut self, socket: SocketAddr, key: &K, is_tcp: bool) -> Result<(), Error> {
         let (port_string, port_v6_string): (Key, Key) = if is_tcp {
             ("tcp".into(), "tcp6".into())
         } else {
@@ -687,14 +687,14 @@ impl<K: EnrKey> Enr<K> {
                     }
                 }
             }
-            return Err(EnrError::ExceedsMaxSize);
+            return Err(Error::ExceedsMaxSize);
         }
 
         // increment the sequence number
         self.seq = self
             .seq
             .checked_add(1)
-            .ok_or(EnrError::SequenceNumberTooHigh)?;
+            .ok_or(Error::SequenceNumberTooHigh)?;
 
         // sign the record
         self.sign(key)?;
@@ -716,7 +716,7 @@ impl<K: EnrKey> Enr<K> {
         remove_keys: impl Iterator<Item = impl AsRef<[u8]>>,
         insert_key_values: impl Iterator<Item = (impl AsRef<[u8]>, &'a [u8])>,
         enr_key: &K,
-    ) -> Result<(PreviousRlpEncodedValues, PreviousRlpEncodedValues), EnrError> {
+    ) -> Result<(PreviousRlpEncodedValues, PreviousRlpEncodedValues), Error> {
         let enr_backup = self.clone();
 
         let mut removed = Vec::new();
@@ -736,14 +736,13 @@ impl<K: EnrKey> Enr<K> {
             // currently only support "v4" identity schemes
             if key.as_ref() == b"id" && value != b"v4" {
                 *self = enr_backup;
-                return Err(EnrError::UnsupportedIdentityScheme);
+                return Err(Error::UnsupportedIdentityScheme);
             }
 
             let value = rlp::encode(&(value)).freeze();
             // Prevent inserting invalid RLP integers
             if is_keyof_u16(key.as_ref()) {
-                rlp::decode::<u16>(&value)
-                    .map_err(|err| EnrError::InvalidRlpData(err.to_string()))?;
+                rlp::decode::<u16>(&value).map_err(|err| Error::InvalidRlpData(err.to_string()))?;
             }
 
             inserted.push(self.content.insert(key.as_ref().to_vec(), value));
@@ -753,7 +752,7 @@ impl<K: EnrKey> Enr<K> {
         self.seq = self
             .seq
             .checked_add(1)
-            .ok_or(EnrError::SequenceNumberTooHigh)?;
+            .ok_or(Error::SequenceNumberTooHigh)?;
 
         // sign the record
         self.sign(enr_key)?;
@@ -765,14 +764,14 @@ impl<K: EnrKey> Enr<K> {
             // in case the signature size changes, inform the user the size has exceeded the
             // maximum
             *self = enr_backup;
-            return Err(EnrError::ExceedsMaxSize);
+            return Err(Error::ExceedsMaxSize);
         }
 
         Ok((removed, inserted))
     }
 
     /// Sets a new public key for the record.
-    pub fn set_public_key(&mut self, public_key: &K::PublicKey, key: &K) -> Result<(), EnrError> {
+    pub fn set_public_key(&mut self, public_key: &K::PublicKey, key: &K) -> Result<(), Error> {
         self.insert(&public_key.enr_key(), &public_key.encode().as_ref(), key)
             .map(|_| {})
     }
@@ -816,19 +815,19 @@ impl<K: EnrKey> Enr<K> {
     }
 
     /// Compute the enr's signature with the given key.
-    fn compute_signature(&self, signing_key: &K) -> Result<Vec<u8>, EnrError> {
+    fn compute_signature(&self, signing_key: &K) -> Result<Vec<u8>, Error> {
         match self.id() {
             Some(ref id) if id == "v4" => signing_key
                 .sign_v4(&self.rlp_content())
-                .map_err(|_| EnrError::SigningError),
+                .map_err(|_| Error::SigningError),
             // other identity schemes are unsupported
-            _ => Err(EnrError::UnsupportedIdentityScheme),
+            _ => Err(Error::UnsupportedIdentityScheme),
         }
     }
 
     /// Signs the ENR record based on the identity scheme. Currently only "v4" is supported.
     /// The previous signature is returned.
-    fn sign(&mut self, key: &K) -> Result<Vec<u8>, EnrError> {
+    fn sign(&mut self, key: &K) -> Result<Vec<u8>, Error> {
         let new_signature = self.compute_signature(key)?;
         Ok(std::mem::replace(&mut self.signature, new_signature))
     }
@@ -1074,35 +1073,35 @@ const fn is_keyof_u16(key: &[u8]) -> bool {
     matches!(key, b"tcp" | b"tcp6" | b"udp" | b"udp6")
 }
 
-fn check_spec_reserved_keys(key: &[u8], value: &[u8]) -> Result<(), EnrError> {
+fn check_spec_reserved_keys(key: &[u8], value: &[u8]) -> Result<(), Error> {
     match key {
         b"tcp" | b"tcp6" | b"udp" | b"udp6" => {
-            rlp::decode::<u16>(value).map_err(|err| EnrError::InvalidRlpData(err.to_string()))?;
+            rlp::decode::<u16>(value).map_err(|err| Error::InvalidRlpData(err.to_string()))?;
         }
         b"id" => {
             let id_bytes = rlp::decode::<Vec<u8>>(value)
-                .map_err(|err| EnrError::InvalidRlpData(err.to_string()))?;
+                .map_err(|err| Error::InvalidRlpData(err.to_string()))?;
             if id_bytes != b"v4" {
-                return Err(EnrError::UnsupportedIdentityScheme);
+                return Err(Error::UnsupportedIdentityScheme);
             }
         }
         b"ip" => {
             let ip4_bytes = rlp::decode::<Vec<u8>>(value)
-                .map_err(|err| EnrError::InvalidRlpData(err.to_string()))?;
+                .map_err(|err| Error::InvalidRlpData(err.to_string()))?;
             if ip4_bytes.len() != 4 {
-                return Err(EnrError::InvalidRlpData("Invalid Ipv4 size".to_string()));
+                return Err(Error::InvalidRlpData("Invalid Ipv4 size".to_string()));
             }
         }
         b"ip6" => {
             let ip6_bytes = rlp::decode::<Vec<u8>>(value)
-                .map_err(|err| EnrError::InvalidRlpData(err.to_string()))?;
+                .map_err(|err| Error::InvalidRlpData(err.to_string()))?;
             if ip6_bytes.len() != 16 {
-                return Err(EnrError::InvalidRlpData("Invalid Ipv6 size".to_string()));
+                return Err(Error::InvalidRlpData("Invalid Ipv6 size".to_string()));
             }
         }
         b"secp256k1" => {
             rlp::decode::<Enr<k256::ecdsa::SigningKey>>(value)
-                .map_err(|err| EnrError::InvalidRlpData(err.to_string()))?;
+                .map_err(|err| Error::InvalidRlpData(err.to_string()))?;
         }
         _ => return Ok(()),
     };
@@ -1756,10 +1755,7 @@ mod tests {
         let mut record = LARGE_ENR.parse::<DefaultEnr>().unwrap();
         let enr_bkp = record.clone();
         // verify that updating the sequence number when it won't fit is rejected
-        assert_eq!(
-            record.set_seq(u64::MAX, &key),
-            Err(EnrError::ExceedsMaxSize)
-        );
+        assert_eq!(record.set_seq(u64::MAX, &key), Err(Error::ExceedsMaxSize));
         // verify the enr is unchanged after this operation
         assert_eq!(record, enr_bkp);
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1087,13 +1087,17 @@ fn check_spec_reserved_keys(key: &[u8], value: &[u8]) -> Result<(), Error> {
         b"ip" => {
             let ip4_bytes = rlp::decode::<Vec<u8>>(value)?;
             if ip4_bytes.len() != 4 {
-                return Err(Error::InvalidRlpData("Invalid Ipv4 size".to_string()));
+                return Err(Error::InvalidRlpData(rlp::DecoderError::Custom(
+                    "invalid IPv4 bytes length",
+                )));
             }
         }
         b"ip6" => {
             let ip6_bytes = rlp::decode::<Vec<u8>>(value)?;
             if ip6_bytes.len() != 16 {
-                return Err(Error::InvalidRlpData("Invalid Ipv6 size".to_string()));
+                return Err(Error::InvalidRlpData(rlp::DecoderError::Custom(
+                    "invalid IPv6 bytes lenght",
+                )));
             }
         }
         _ => return Ok(()),


### PR DESCRIPTION
renames `EnrError` to `enr::Error` to keep naming uniform
Also removes the assertion over `secp256k1` 