### PR TITLE
fix: decode rlp header on Enr::build

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ secp256k1 = { version = "0.28", optional = true, default-features = false, featu
 ] }
 
 [dev-dependencies]
+alloy-rlp = { version = "0.3.4", features = ["derive"] }
 secp256k1 = { features = ["rand-std"], version = "0.28" }
 serde_json = { version = "1.0.114" }
 

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -1,5 +1,5 @@
 use crate::{Enr, EnrKey, EnrPublicKey, Error, Key, NodeId, MAX_ENR_SIZE};
-use alloy_rlp::{Decodable, Encodable, Header};
+use alloy_rlp::{Encodable, Header};
 use bytes::{Bytes, BytesMut};
 use std::{
     collections::BTreeMap,
@@ -158,7 +158,7 @@ impl<K: EnrKey> Builder<K> {
 
         // Sanitize all data, ensuring all RLP data is correctly formatted.
         for value in self.content.values() {
-            Bytes::decode(&mut value.as_ref())?;
+            Header::decode(&mut value.as_ref())?;
         }
 
         let mut id_bytes = BytesMut::with_capacity(3);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -270,8 +270,8 @@ impl<K: EnrKey> Enr<K> {
     pub fn get(&self, key: impl AsRef<[u8]>) -> Option<Bytes> {
         // It's ok to decode any valid RLP value as data
         self.get_raw_rlp(key).map(|mut rlp_data| {
-            let mut raw_data = &mut rlp_data;
-            let header = Header::decode(&mut raw_data).expect("All data is sanitized");
+            let raw_data = &mut rlp_data;
+            let header = Header::decode(raw_data).expect("All data is sanitized");
             raw_data[..header.payload_length].to_vec().into()
         })
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1149,7 +1149,6 @@ fn check_spec_reserved_keys(key: &[u8], mut value: &[u8]) -> Result<(), Error> {
 mod tests {
     use super::*;
     use std::convert::TryFrom;
-    use std::net::Ipv4Addr;
 
     type DefaultEnr = Enr<k256::ecdsa::SigningKey>;
 
@@ -1497,6 +1496,31 @@ mod tests {
         assert_eq!(decoded_enr.tcp4(), Some(tcp));
         assert_eq!(decoded_enr.public_key().encode(), key.public().encode());
         assert!(decoded_enr.verify());
+    }
+
+    #[test]
+    fn test_add_content_value() {
+        #[derive(PartialEq, Eq, Debug, alloy_rlp::RlpEncodable, alloy_rlp::RlpDecodable)]
+        struct Proto {
+            name: String,
+            version: u64,
+        }
+
+        let mut rng = rand::thread_rng();
+        let key = k256::ecdsa::SigningKey::random(&mut rng);
+        let proto = Proto {
+            name: "test".to_string(),
+            version: 1,
+        };
+
+        let enr = Enr::builder()
+            .add_value("proto", &proto)
+            .build(&key)
+            .unwrap();
+
+        let decoded_proto = enr.get_decodable::<Proto>("proto").unwrap().unwrap();
+
+        assert_eq!(decoded_proto, proto);
     }
 
     #[test]


### PR DESCRIPTION
closes #71

https://github.com/sigp/enr/issues/71#issuecomment-2033297989

> Unless the .build() fails on normal types, it should be the case that all rlp-bytes can be decoded as bytes right?

This changes the sanitize check from `Bytes::decode` to `Header::decode`,
this is required for list types that are added via `Builder::add_value` because `Bytes::decode` 
fails on lists:
https://github.com/alloy-rs/rlp/blob/2ccf23f7b6a363c844443a13f9496391ee6892ac/crates/rlp/src/decode.rs#L83

added new test that fails on main:

```
test tests::test_add_content_value ... FAILED

failures:

---- tests::test_add_content_value stdout ----
thread 'tests::test_add_content_value' panicked at src/lib.rs:1519:14:
called `Result::unwrap()` on an `Err` value: InvalidRlpData(UnexpectedList)
```

also update `Enr::get` to restore the previous behaviour of rlp::data which returns the payload data

https://docs.rs/rlp/latest/src/rlp/rlpin.rs.html#159

we could add a `Bytes::decode_unchecked` to alloy-rlp that does not care about list

cc @DaniPopes 
