### PR TITLE
fix: broken decoding

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -265,10 +265,10 @@ impl<K: EnrKey> Enr<K> {
         self.seq
     }
 
-    /// Reads a custom key from the record if it exists, decoded as data.
+    /// Reads a custom key from the record if it exists, decoded as data. Caution! Only use for
+    /// data that is not an aggregate type. Default to using [`get_decodable`](Enr::get_decodable).
     #[allow(clippy::missing_panics_doc)]
     pub fn get(&self, key: impl AsRef<[u8]>) -> Option<Bytes> {
-        // It's ok to decode any valid RLP value as data
         self.get_raw_rlp(key).map(|mut rlp_data| {
             let raw_data = &mut rlp_data;
             let header = Header::decode(raw_data).expect("All data is sanitized");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1031,19 +1031,6 @@ impl<K: EnrKey> Decodable for Enr<K> {
                     let keys = Header::decode_bytes(payload, false)?;
                     alloy_rlp::encode(keys)
                 }
-                b"eth" => {
-                    let eth_header = Header::decode(payload)?;
-                    let value = &mut &payload[..eth_header.payload_length];
-                    payload.advance(eth_header.payload_length);
-                    let val_header = Header {
-                        list: true,
-                        payload_length: value.len(),
-                    };
-                    let mut out = Vec::<u8>::new();
-                    val_header.encode(&mut out);
-                    out.extend_from_slice(value);
-                    out
-                }
                 _ => {
                     let other_header = Header::decode(payload)?;
                     let value = &mut &payload[..other_header.payload_length];


### PR DESCRIPTION
Thanks to very important find by @mattsse. All enrs with for example "eth2" kv-pair have failed decoding.

- Fixes decoding of enr with an custom kv pair