### PR TITLE
chore: bump secp256k1 to 0.29

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,13 +23,13 @@ sha3 = "0.10"
 k256 = { version = "0.13", features = ["ecdsa"], optional = true }
 serde = { version = "1.0", features = ["derive"], optional = true }
 ed25519-dalek = { version = "2.1.1", optional = true, features = ["rand_core"] }
-secp256k1 = { version = "0.28", optional = true, default-features = false, features = [
+secp256k1 = { version = "0.29", optional = true, default-features = false, features = [
     "global-context",
 ] }
 
 [dev-dependencies]
 alloy-rlp = { version = "0.3.4", features = ["derive"] }
-secp256k1 = { version = "0.28", features = ["rand-std"] }
+secp256k1 = { version = "0.29", features = ["rand-std"] }
 serde_json = "1.0"
 
 [features]


### PR DESCRIPTION
Version bump seems relatively small
https://github.com/rust-bitcoin/rust-secp256k1/blob/master/CHANGELOG.md