### PR TITLE
Revert to raw encoding for non-list entries

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1044,7 +1044,7 @@ impl<K: EnrKey> Decodable for Enr<K> {
                     payload.advance(other_header.payload_length);
 
                     // Encode the header for list values, for non-list objects, we remove the
-                    // header for compatibility with commonly used key entries (i.e its the
+                    // header for compatibility with commonly used key entries (i.e it's the
                     // current convention).
                     if other_header.list {
                         let mut out = Vec::<u8>::new();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1968,4 +1968,17 @@ mod tests {
         record.set_seq(30, &key).unwrap();
         assert_eq!(record.seq(), 30);
     }
+
+    /// Tests a common ENR which uses RLP encoded values without the header
+    #[test]
+    fn test_common_rlp_convention() {
+        const COMMON_VALID_ENR: &str = concat!(
+            "-LW4QCAyOCtqvQjd8AgpqbaCgfjy8oN8cBBRT5jtzarkGJQWZx1eN70EM0QafVCugLa-Bv493DPNzflagqfTOsWSF78Ih2F0d",
+            "G5ldHOIAGAAAAAAAACEZXRoMpBqlaGpBAAAAP__________gmlkgnY0hHF1aWOCIymJc2VjcDI1NmsxoQPg_HgqXzwRIK39Oy",
+            "lGdC30YUFwsfXvATnGUvEZ6MtBQIhzeW5jbmV0cwCDdGNwgiMo"
+        );
+
+        // Expect this to be able to be decoded
+        let _decoded: DefaultEnr = COMMON_VALID_ENR.parse().unwrap();
+    }
 }


### PR DESCRIPTION
The standard convention for signing RLP field data is to do so without the RLP header. 

This was a point of confusion in the last version upgrade where no one had really accounted for RLP lists as values. The last version introduced storing the RLP header along with the value when decoding or reading an ENR. This goes against common convention and as a result, the current version cannot read a variety of common ENRs which are implementing fields with non-list RLP types. 

This PR reverts the previous changes such that the signature is over RLP data without the header. 

However if there is an RLP list object being encoded, we maintain the header. This may not be the common convention with other ENR crates and we might want to consider spec'ing the case of RLP list fields to avoid this confusion between various ENR implementations. 