### PR TITLE
Creating BytesMut with appropriate capacity in ENR Builder

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -44,7 +44,7 @@ impl<K: EnrKey> Builder<K> {
 
     /// Adds an arbitrary key-value to the `ENRBuilder`.
     pub fn add_value<T: Encodable>(&mut self, key: impl AsRef<[u8]>, value: &T) -> &mut Self {
-        let mut out = BytesMut::new();
+        let mut out = BytesMut::with_capacity(value.length());
         value.encode(&mut out);
         self.add_value_rlp(key, out.freeze())
     }
@@ -140,7 +140,7 @@ impl<K: EnrKey> Builder<K> {
             list: true,
             payload_length: list.len(),
         };
-        let mut out = BytesMut::new();
+        let mut out = BytesMut::with_capacity(header.length() + list.len());
         header.encode(&mut out);
         out.extend_from_slice(&list);
         out
@@ -177,7 +177,7 @@ impl<K: EnrKey> Builder<K> {
             Header::decode(&mut value.as_ref())?;
         }
 
-        let mut id_bytes = BytesMut::with_capacity(3);
+        let mut id_bytes = BytesMut::with_capacity(self.id.length());
         self.id.as_bytes().encode(&mut id_bytes);
         self.add_value_rlp("id", id_bytes.freeze());
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -833,7 +833,7 @@ impl<K: EnrKey> Enr<K> {
 
     /// Sets a new public key for the record.
     pub fn set_public_key(&mut self, public_key: &K::PublicKey, key: &K) -> Result<(), Error> {
-        self.insert(&public_key.enr_key(), &public_key.encode().as_ref(), key)
+        self.insert(public_key.enr_key(), &public_key.encode().as_ref(), key)
             .map(|_| {})
     }
 


### PR DESCRIPTION
Was going through the sourcecode, trying to understand what are Ethereum Node Records (ENRs). Noticed that we can create `BytesMut` **specifying the capacity** everytime, in the **ENR builder** module.

So here i made a PR :).