### PR TITLE
Version bump to 13 and update dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ secp256k1 = { version = "0.30", optional = true, default-features = false, featu
 
 [dev-dependencies]
 alloy-rlp = { version = "0.3", features = ["derive"] }
-secp256k1 = { version = "0.30" }
+secp256k1 = { version = "0.30", features = ["rand"] }
 serde_json = "1.0"
 
 [features]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "enr"
 authors = ["Age Manning <Age@AgeManning.com>"]
 edition = "2021"
-version = "0.12.1"
+version = "0.13.0"
 description = "Rust implementation of Ethereum Node Record (ENR) EIP778"
 readme = "./README.md"
 keywords = ["ethereum", "enr", "record", "EIP778", "node"]
@@ -12,24 +12,24 @@ license = "MIT"
 exclude = [".gitignore", ".github/*"]
 
 [dependencies]
-alloy-rlp = "0.3.4"
-base64 = "0.21"
+alloy-rlp = "0.3.9"
+base64 = "0.22"
 bytes = "1"
-hex = "0.4.3"
-log = "0.4.21"
+hex = "0.4"
+log = "0.4"
 rand = "0.8"
-zeroize = "1.7.0"
+zeroize = "1.8"
 sha3 = "0.10"
 k256 = { version = "0.13", features = ["ecdsa"], optional = true }
 serde = { version = "1.0", features = ["derive"], optional = true }
-ed25519-dalek = { version = "2.1.1", optional = true, features = ["rand_core"] }
-secp256k1 = { version = "0.29", optional = true, default-features = false, features = [
+ed25519-dalek = { version = "2.1", optional = true, features = ["rand_core"] }
+secp256k1 = { version = "0.30", optional = true, default-features = false, features = [
     "global-context",
 ] }
 
 [dev-dependencies]
-alloy-rlp = { version = "0.3.4", features = ["derive"] }
-secp256k1 = { version = "0.29", features = ["rand-std"] }
+alloy-rlp = { version = "0.3", features = ["derive"] }
+secp256k1 = { version = "0.30" }
 serde_json = "1.0"
 
 [features]


### PR DESCRIPTION
This updates ENRs dependencies to the latest version and bumps to v0.13 for a new release. 
