### PR TITLE
wipfeat: no-std support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,14 +12,14 @@ license = "MIT"
 exclude = [".gitignore", ".github/*"]
 
 [dependencies]
-alloy-rlp = "0.3.9"
-base64 = "0.22"
-bytes = "1"
-hex = "0.4"
-log = "0.4"
-rand = "0.8"
-zeroize = "1.8"
-sha3 = "0.10"
+alloy-rlp = { version = "0.3.9", default-features = false }
+base64 = { version ="0.22", default-features = false }
+bytes = { version = "1", default-features = false }
+hex = { version = "0.4", default-features = false, features = ["alloc"] }
+log = { version = "0.4", default-features = false }
+rand = { version = "0.8", optional = true }
+zeroize = { version = "1.8", default-features = false }
+sha3 = { version = "0.10", default-features = false }
 k256 = { version = "0.13", features = ["ecdsa"], optional = true }
 serde = { version = "1.0", features = ["derive"], optional = true }
 ed25519-dalek = { version = "2.1", optional = true, features = ["rand_core"] }
@@ -28,17 +28,30 @@ secp256k1 = { version = "0.30", optional = true, default-features = false, featu
 ] }
 
 [dev-dependencies]
+rand = "0.8"
 alloy-rlp = { version = "0.3", features = ["derive"] }
 secp256k1 = { version = "0.30", features = ["rand"] }
 serde_json = "1.0"
 
 [features]
-default = ["serde", "k256"]
-serde = ["dep:serde"]
-k256 = ["dep:k256"]
+default = ["std", "serde", "k256"]
+std = ["alloy-rlp/std", "bytes/std" ,"base64/std", "hex/std", "log/std", "sha3/std", "zeroize/std"]
+serde = [
+	"dep:serde",
+	"bytes/serde",
+	"ed25519-dalek?/serde",
+	"hex/serde",
+	"k256?/serde",
+	"log/serde",
+	"rand?/serde",
+	"secp256k1?/serde",
+	"zeroize/serde"
+]
+k256 = ["dep:k256", "rand"]
 ed25519 = ["dep:ed25519-dalek"]
 secp256k1 = ["rust-secp256k1"]
 rust-secp256k1 = ["dep:secp256k1"]
+rand = ["dep:rand"]
 
 [lib]
 name = "enr"

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -3,10 +3,13 @@ use crate::{
     ENR_VERSION, ID_ENR_KEY, IP6_ENR_KEY, IP_ENR_KEY, TCP6_ENR_KEY, TCP_ENR_KEY, UDP6_ENR_KEY,
     UDP_ENR_KEY,
 };
+use alloc::collections::BTreeMap;
+use alloc::string::String;
+use alloc::vec;
+use alloc::vec::Vec;
 use alloy_rlp::{Encodable, Header};
 use bytes::{Bytes, BytesMut};
-use std::{
-    collections::BTreeMap,
+use core::{
     marker::PhantomData,
     net::{IpAddr, Ipv4Addr, Ipv6Addr},
 };

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,6 +1,6 @@
 //! The error type emitted for various ENR operations.
 
-use std::fmt;
+use core::fmt;
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 /// An error type for handling various ENR operations.
@@ -35,8 +35,8 @@ impl fmt::Display for Error {
     }
 }
 
-impl std::error::Error for Error {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+impl core::error::Error for Error {
+    fn source(&self) -> Option<&(dyn core::error::Error + 'static)> {
         match self {
             Error::ExceedsMaxSize
             | Error::SequenceNumberTooHigh

--- a/src/keys/mod.rs
+++ b/src/keys/mod.rs
@@ -23,14 +23,16 @@ pub use k256;
 #[cfg(feature = "rust-secp256k1")]
 pub use secp256k1;
 
+use crate::alloc::string::ToString;
 use crate::Key;
+use alloc::boxed::Box;
+use alloc::collections::BTreeMap;
+use alloc::string::String;
+use alloc::vec::Vec;
 use alloy_rlp::Error as DecoderError;
 use bytes::Bytes;
-use std::{
-    collections::BTreeMap,
-    error::Error,
-    fmt::{self, Debug, Display},
-};
+use core::error::Error;
+use core::fmt::{self, Debug, Display};
 
 /// The trait required for a key to sign and modify an ENR record.
 pub trait EnrKey: Send + Sync + Unpin + 'static {

--- a/src/node_id.rs
+++ b/src/node_id.rs
@@ -29,12 +29,13 @@ impl NodeId {
         }
 
         let mut raw: RawNodeId = [0_u8; 32];
-        raw[..std::cmp::min(32, raw_input.len())].copy_from_slice(raw_input);
+        raw[..core::cmp::min(32, raw_input.len())].copy_from_slice(raw_input);
 
         Ok(Self { raw })
     }
 
     /// Generates a random `NodeId`.
+    #[cfg(feature = "rand")]
     #[must_use]
     pub fn random() -> Self {
         Self {
@@ -86,8 +87,8 @@ impl From<RawNodeId> for NodeId {
     }
 }
 
-impl std::fmt::Display for NodeId {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+impl core::fmt::Display for NodeId {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
         let hex_encode = hex::encode(self.raw);
         write!(
             f,
@@ -98,8 +99,8 @@ impl std::fmt::Display for NodeId {
     }
 }
 
-impl std::fmt::Debug for NodeId {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+impl core::fmt::Debug for NodeId {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
         write!(f, "0x{}", hex::encode(self.raw))
     }
 }
@@ -121,7 +122,7 @@ mod serde_hex_prfx {
     where
         D: serde::Deserializer<'de>,
         T: hex::FromHex,
-        <T as hex::FromHex>::Error: std::fmt::Display,
+        <T as hex::FromHex>::Error: core::fmt::Display,
     {
         /// Helper struct to obtain a owned string when necessary (using [`serde_json`], for
         /// example) or a borrowed string with the appropriate lifetime (most the time).


### PR DESCRIPTION
tbh I'm not exactly sure this will be useful at all, but I encountered this while looking into converting more reth crates to no-std, so I looked into it for a bit.

this currently still fails because alloy-rlp is still on msrv 1.64 before Ip-net types were moved to core.
we can work around this by introducing a separate feature for this on alloy-rlp (https://github.com/alloy-rs/rlp/pull/30).

I couldn't find a msrv, using `core::error::Error` would require msrv 1.81, alternatively this could likely be feature gated.

totally fine if no-std is not planned or even useful, I assume k256 could work though
