### PR TITLE
Update dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,24 +12,24 @@ license = "MIT"
 exclude = [".gitignore", ".github/*"]
 
 [dependencies]
-alloy-rlp = "0.3.9"
+alloy-rlp = "0.3.12"
 base64 = "0.22"
 bytes = "1"
 hex = "0.4"
 log = "0.4"
-rand = "0.8"
+rand = "0.9"
 zeroize = "1.8"
-sha3 = "0.10"
-k256 = { version = "0.13", features = ["ecdsa"], optional = true }
+sha3 = "0.11.0-rc.3"
+k256 = { version = "0.14.0-pre.10", features = ["ecdsa"], optional = true }
 serde = { version = "1.0", features = ["derive"], optional = true }
 ed25519-dalek = { version = "2.1", optional = true, features = ["rand_core"] }
-secp256k1 = { version = "0.30", optional = true, default-features = false, features = [
+secp256k1 = { version = "0.31", optional = true, default-features = false, features = [
     "global-context",
 ] }
 
 [dev-dependencies]
 alloy-rlp = { version = "0.3", features = ["derive"] }
-secp256k1 = { version = "0.30", features = ["rand"] }
+secp256k1 = { version = "0.31", features = ["rand"] }
 serde_json = "1.0"
 
 [features]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ zeroize = "1.8"
 sha3 = "0.11.0-rc.3"
 k256 = { version = "0.14.0-pre.10", features = ["ecdsa"], optional = true }
 serde = { version = "1.0", features = ["derive"], optional = true }
-ed25519-dalek = { version = "2.1", optional = true, features = ["rand_core"] }
+ed25519-dalek = { version = "3.0.0-pre.1", optional = true, features = ["rand_core"] }
 secp256k1 = { version = "0.31", optional = true, default-features = false, features = [
     "global-context",
 ] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,19 +17,19 @@ base64 = "0.22"
 bytes = "1"
 hex = "0.4"
 log = "0.4"
-rand = "0.8"
+rand = "0.9"
 zeroize = "1.8"
-sha3 = "0.10"
-k256 = { version = "0.13", features = ["ecdsa"], optional = true }
+sha3 = "0.11.0-rc.3"
+k256 = { version = "0.14.0-pre.10", features = ["ecdsa"], optional = true }
 serde = { version = "1.0", features = ["derive"], optional = true }
 ed25519-dalek = { version = "2.1", optional = true, features = ["rand_core"] }
-secp256k1 = { version = "0.30", optional = true, default-features = false, features = [
+secp256k1 = { version = "0.31", optional = true, default-features = false, features = [
     "global-context",
 ] }
 
 [dev-dependencies]
 alloy-rlp = { version = "0.3", features = ["derive"] }
-secp256k1 = { version = "0.30", features = ["rand"] }
+secp256k1 = { version = "0.31", features = ["rand"] }
 serde_json = "1.0"
 
 [features]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ hex = "0.4"
 log = "0.4"
 rand = "0.9"
 zeroize = "1.8"
-sha3 = "0.11.0-rc.3"
+sha3 = "0.11"
 k256 = { version = "0.14.0-pre.10", features = ["ecdsa"], optional = true }
 serde = { version = "1.0", features = ["derive"], optional = true }
 ed25519-dalek = { version = "3.0.0-pre.1", optional = true, features = ["rand_core"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,12 +17,12 @@ base64 = "0.22"
 bytes = "1"
 hex = "0.4"
 log = "0.4"
-rand = "0.9"
+rand = "0.10"
 zeroize = "1.8"
 sha3 = "0.11"
-k256 = { version = "0.14.0-pre.10", features = ["ecdsa"], optional = true }
+k256 = { version = "0.14.0-rc.8", features = ["ecdsa"], optional = true }
 serde = { version = "1.0", features = ["derive"], optional = true }
-ed25519-dalek = { version = "3.0.0-pre.1", optional = true, features = ["rand_core"] }
+ed25519-dalek = { version = "3.0.0-pre.6", optional = true, features = ["rand_core"] }
 secp256k1 = { version = "0.31", optional = true, default-features = false, features = [
     "global-context",
 ] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ log = "0.4"
 rand = "0.10"
 zeroize = "1.8"
 sha3 = "0.11"
-k256 = { version = "0.14.0-rc.8", features = ["ecdsa"], optional = true }
+k256 = { version = "0.14", features = ["ecdsa"], optional = true }
 serde = { version = "1.0", features = ["derive"], optional = true }
 ed25519-dalek = { version = "3.0.0-pre.6", optional = true, features = ["rand_core"] }
 secp256k1 = { version = "0.31", optional = true, default-features = false, features = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ zeroize = "1.8"
 sha3 = "0.11"
 k256 = { version = "0.14", features = ["ecdsa"], optional = true }
 serde = { version = "1.0", features = ["derive"], optional = true }
-ed25519-dalek = { version = "3.0.0-pre.6", optional = true, features = ["rand_core"] }
+ed25519-dalek = { version = "3.0", optional = true, features = ["rand_core"] }
 secp256k1 = { version = "0.31", optional = true, default-features = false, features = [
     "global-context",
 ] }

--- a/README.md
+++ b/README.md
@@ -60,10 +60,10 @@ enr = { version = "*", features = ["serde", "ed25519", "rust-secp256k1"] }
 ```rust
 use enr::{Enr, k256};
 use std::net::Ipv4Addr;
-use rand::thread_rng;
+use rand::rng;
 
 // generate a random secp256k1 key
-let mut rng = thread_rng();
+let mut rng = rng();
 let key = k256::ecdsa::SigningKey::random(&mut rng);
 
 let ip = Ipv4Addr::new(192,168,0,1);
@@ -103,13 +103,13 @@ can be added using `insert` and retrieved with `get`.
 ```rust
 use enr::{k256::ecdsa::SigningKey, Enr};
 use std::net::Ipv4Addr;
-use rand::thread_rng;
+use rand::rng;
 
 // specify the type of ENR
 type DefaultEnr = Enr<SigningKey>;
 
 // generate a random secp256k1 key
-let mut rng = thread_rng();
+let mut rng = rng();
 let key = SigningKey::random(&mut rng);
 
 let ip = Ipv4Addr::new(192,168,0,1);
@@ -136,10 +136,10 @@ assert_eq!(decoded_enr.get("custom_key").as_ref().map(AsRef::as_ref), Some(vec![
 ```rust
 use enr::{ed25519_dalek as ed25519, k256::ecdsa, CombinedKey, Enr};
 use std::net::Ipv4Addr;
-use rand::thread_rng;
+use rand::rng;
 
 // generate a random secp256k1 key
-let mut rng = thread_rng();
+let mut rng = rng();
 let key = ecdsa::SigningKey::random(&mut rng);
 let ip = Ipv4Addr::new(192, 168, 0, 1);
 let enr_secp256k1 = Enr::builder().ip4(ip).tcp4(8000).build(&key).unwrap();

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -122,10 +122,10 @@ impl<K: EnrKey> Builder<K> {
         version: String,
         build: Option<String>,
     ) -> &mut Self {
-        if build.is_none() {
-            self.add_value("client", &vec![name, version]);
+        if let Some(build) = build {
+            self.add_value("client", &vec![name, version, build]);
         } else {
-            self.add_value("client", &vec![name, version, build.unwrap()]);
+            self.add_value("client", &vec![name, version]);
         }
 
         self

--- a/src/keys/combined.rs
+++ b/src/keys/combined.rs
@@ -67,14 +67,14 @@ impl CombinedKey {
     /// Generates a new secp256k1 key.
     #[must_use]
     pub fn generate_secp256k1() -> Self {
-        let key = k256::ecdsa::SigningKey::random(&mut rand::thread_rng());
+        let key = k256::ecdsa::SigningKey::random(&mut rand::rng());
         Self::Secp256k1(key)
     }
 
     /// Generates a new ed25510 key.
     #[must_use]
     pub fn generate_ed25519() -> Self {
-        Self::Ed25519(ed25519::SigningKey::generate(&mut rand::thread_rng()))
+        Self::Ed25519(ed25519::SigningKey::generate(&mut rand::rng()))
     }
 
     /// Imports a secp256k1 from raw bytes in any format.

--- a/src/keys/combined.rs
+++ b/src/keys/combined.rs
@@ -7,6 +7,7 @@ use super::{ed25519_dalek as ed25519, EnrKey, EnrPublicKey, SigningError};
 use crate::Key;
 use alloy_rlp::Error as DecoderError;
 use bytes::Bytes;
+use k256::elliptic_curve::Generate;
 use std::collections::BTreeMap;
 use zeroize::Zeroize;
 
@@ -67,7 +68,7 @@ impl CombinedKey {
     /// Generates a new secp256k1 key.
     #[must_use]
     pub fn generate_secp256k1() -> Self {
-        let key = k256::ecdsa::SigningKey::random(&mut rand::rng());
+        let key = k256::ecdsa::SigningKey::generate_from_rng(&mut rand::rng());
         Self::Secp256k1(key)
     }
 

--- a/src/keys/k256_key.rs
+++ b/src/keys/k256_key.rs
@@ -11,12 +11,12 @@ use k256::{
     },
     elliptic_curve::{
         point::DecompressPoint,
-        sec1::{Coordinates, ToEncodedPoint},
+        sec1::{Coordinates, ToSec1Point},
         subtle::Choice,
     },
-    AffinePoint, CompressedPoint, EncodedPoint,
+    AffinePoint, CompressedPoint,
 };
-use rand::rngs::OsRng;
+use rand::rngs::SysRng;
 use sha3::{Digest, Keccak256};
 use std::collections::BTreeMap;
 
@@ -29,7 +29,7 @@ impl EnrKey for SigningKey {
     fn sign_v4(&self, msg: &[u8]) -> Result<Vec<u8>, SigningError> {
         // take a keccak256 hash then sign.
         let signature: Signature = self
-            .try_sign_digest_with_rng(&mut OsRng, |digest: &mut Keccak256| {
+            .try_sign_digest_with_rng(&mut SysRng, |digest: &mut Keccak256| {
                 digest.update(msg);
                 Ok(())
             })
@@ -87,14 +87,14 @@ impl EnrPublicKey for VerifyingKey {
     }
 
     fn encode_uncompressed(&self) -> Self::RawUncompressed {
-        let p = EncodedPoint::from(self);
+        let p = self.to_sec1_point(false);
         let (x, y) = match p.coordinates() {
             Coordinates::Compact { .. } | Coordinates::Identity => unreachable!(),
             Coordinates::Compressed { x, y_is_odd } => (
                 x,
                 *AffinePoint::decompress(x, Choice::from(u8::from(y_is_odd)))
                     .unwrap()
-                    .to_encoded_point(false)
+                    .to_sec1_point(false)
                     .y()
                     .unwrap(),
             ),

--- a/src/keys/k256_key.rs
+++ b/src/keys/k256_key.rs
@@ -29,7 +29,10 @@ impl EnrKey for SigningKey {
     fn sign_v4(&self, msg: &[u8]) -> Result<Vec<u8>, SigningError> {
         // take a keccak256 hash then sign.
         let signature: Signature = self
-            .try_sign_digest_with_rng(&mut OsRng, |digest: &mut Keccak256| Ok(digest.update(msg)))
+            .try_sign_digest_with_rng(&mut OsRng, |digest: &mut Keccak256| {
+                digest.update(msg);
+                Ok(())
+            })
             .map_err(|_| SigningError::new("failed to sign"))?;
 
         Ok(signature.to_vec())
@@ -66,7 +69,13 @@ impl EnrPublicKey for VerifyingKey {
     fn verify_v4(&self, msg: &[u8], sig: &[u8]) -> bool {
         if let Ok(sig) = k256::ecdsa::Signature::try_from(sig) {
             return self
-                .verify_digest(|digest: &mut Keccak256| Ok(digest.update(msg)), &sig)
+                .verify_digest(
+                    |digest: &mut Keccak256| {
+                        digest.update(msg);
+                        Ok(())
+                    },
+                    &sig,
+                )
                 .is_ok();
         }
         false

--- a/src/keys/k256_key.rs
+++ b/src/keys/k256_key.rs
@@ -28,9 +28,8 @@ impl EnrKey for SigningKey {
 
     fn sign_v4(&self, msg: &[u8]) -> Result<Vec<u8>, SigningError> {
         // take a keccak256 hash then sign.
-        let digest = Keccak256::new().chain_update(msg);
         let signature: Signature = self
-            .try_sign_digest_with_rng(&mut OsRng, digest)
+            .try_sign_digest_with_rng(&mut OsRng, |digest: &mut Keccak256| Ok(digest.update(msg)))
             .map_err(|_| SigningError::new("failed to sign"))?;
 
         Ok(signature.to_vec())
@@ -67,7 +66,7 @@ impl EnrPublicKey for VerifyingKey {
     fn verify_v4(&self, msg: &[u8], sig: &[u8]) -> bool {
         if let Ok(sig) = k256::ecdsa::Signature::try_from(sig) {
             return self
-                .verify_digest(Keccak256::new().chain_update(msg), &sig)
+                .verify_digest(|digest: &mut Keccak256| Ok(digest.update(msg)), &sig)
                 .is_ok();
         }
         false

--- a/src/keys/rust_secp256k1.rs
+++ b/src/keys/rust_secp256k1.rs
@@ -105,8 +105,4 @@ impl RngCore for MockOsRng {
         debug_assert_eq!(dest.len(), MOCK_ECDSA_NONCE_ADDITIONAL_DATA.len());
         dest.copy_from_slice(&MOCK_ECDSA_NONCE_ADDITIONAL_DATA);
     }
-
-    fn try_fill_bytes(&mut self, _dest: &mut [u8]) -> Result<(), rand::Error> {
-        unimplemented!();
-    }
 }

--- a/src/keys/rust_secp256k1.rs
+++ b/src/keys/rust_secp256k1.rs
@@ -27,7 +27,7 @@ impl EnrKey for secp256k1::SecretKey {
             OsRng
                 .try_fill_bytes(&mut noncedata)
                 .map_err(|error| SigningError::new(format!("Failed to fill_bytes: {error}")))?;
-            SECP256K1.sign_ecdsa_with_noncedata(&m, self, &noncedata)
+            SECP256K1.sign_ecdsa_with_noncedata(m, self, &noncedata)
         };
         Ok(signature.serialize_compact().to_vec())
     }
@@ -63,7 +63,7 @@ impl EnrPublicKey for secp256k1::PublicKey {
         let msg = digest(msg);
         if let Ok(sig) = secp256k1::ecdsa::Signature::from_compact(sig) {
             let msg = secp256k1::Message::from_digest(msg);
-            return SECP256K1.verify_ecdsa(&msg, &sig, self).is_ok();
+            return SECP256K1.verify_ecdsa(msg, &sig, self).is_ok();
         }
         false
     }

--- a/src/keys/rust_secp256k1.rs
+++ b/src/keys/rust_secp256k1.rs
@@ -2,16 +2,14 @@ use super::{EnrKey, EnrKeyUnambiguous, EnrPublicKey, SigningError};
 use crate::{digest, Key};
 use alloy_rlp::{Decodable, Error as DecoderError};
 use bytes::Bytes;
-use rand::TryRngCore;
+use rand::TryRng;
 use secp256k1::SECP256K1;
 use std::collections::BTreeMap;
 
 #[cfg(test)]
-use self::MockOsRng as OsRng;
+use self::MockOsRng as SysRng;
 #[cfg(not(test))]
-use rand::rngs::OsRng;
-#[cfg(test)]
-use rand::RngCore;
+use rand::rngs::SysRng;
 
 /// The ENR key that stores the public key in the ENR record.
 pub const ENR_KEY: &str = "secp256k1";
@@ -26,7 +24,7 @@ impl EnrKey for secp256k1::SecretKey {
         // serialize to an uncompressed 64 byte vector
         let signature = {
             let mut noncedata = [0; 32];
-            OsRng
+            SysRng
                 .try_fill_bytes(&mut noncedata)
                 .map_err(|error| SigningError::new(format!("Failed to fill_bytes: {error}")))?;
             SECP256K1.sign_ecdsa_with_noncedata(m, self, &noncedata)
@@ -96,17 +94,20 @@ const MOCK_ECDSA_NONCE_ADDITIONAL_DATA: [u8; 32] = [
 struct MockOsRng;
 
 #[cfg(test)]
-impl RngCore for MockOsRng {
-    fn next_u32(&mut self) -> u32 {
+impl TryRng for MockOsRng {
+    type Error = core::convert::Infallible;
+
+    fn try_next_u32(&mut self) -> Result<u32, Self::Error> {
         unimplemented!();
     }
 
-    fn next_u64(&mut self) -> u64 {
+    fn try_next_u64(&mut self) -> Result<u64, Self::Error> {
         unimplemented!();
     }
 
-    fn fill_bytes(&mut self, dest: &mut [u8]) {
+    fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), Self::Error> {
         debug_assert_eq!(dest.len(), MOCK_ECDSA_NONCE_ADDITIONAL_DATA.len());
         dest.copy_from_slice(&MOCK_ECDSA_NONCE_ADDITIONAL_DATA);
+        Ok(())
     }
 }

--- a/src/keys/rust_secp256k1.rs
+++ b/src/keys/rust_secp256k1.rs
@@ -10,6 +10,8 @@ use std::collections::BTreeMap;
 use self::MockOsRng as OsRng;
 #[cfg(not(test))]
 use rand::rngs::OsRng;
+#[cfg(test)]
+use rand::RngCore;
 
 /// The ENR key that stores the public key in the ENR record.
 pub const ENR_KEY: &str = "secp256k1";

--- a/src/keys/rust_secp256k1.rs
+++ b/src/keys/rust_secp256k1.rs
@@ -2,7 +2,7 @@ use super::{EnrKey, EnrKeyUnambiguous, EnrPublicKey, SigningError};
 use crate::{digest, Key};
 use alloy_rlp::{Decodable, Error as DecoderError};
 use bytes::Bytes;
-use rand::RngCore;
+use rand::TryRngCore;
 use secp256k1::SECP256K1;
 use std::collections::BTreeMap;
 
@@ -24,7 +24,9 @@ impl EnrKey for secp256k1::SecretKey {
         // serialize to an uncompressed 64 byte vector
         let signature = {
             let mut noncedata = [0; 32];
-            OsRng.fill_bytes(&mut noncedata);
+            OsRng
+                .try_fill_bytes(&mut noncedata)
+                .map_err(|error| SigningError::new(format!("Failed to fill_bytes: {error}")))?;
             SECP256K1.sign_ecdsa_with_noncedata(&m, self, &noncedata)
         };
         Ok(signature.serialize_compact().to_vec())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,10 +53,10 @@
 //! # #[cfg(feature = "k256")] {
 //! use enr::{Enr, k256};
 //! use std::net::Ipv4Addr;
-//! use rand::thread_rng;
+//! use rand::rng;
 //!
 //! // generate a random secp256k1 key
-//! let mut rng = thread_rng();
+//! let mut rng = rng();
 //! let key = k256::ecdsa::SigningKey::random(&mut rng);
 //!
 //! let ip = Ipv4Addr::new(192,168,0,1);
@@ -99,13 +99,13 @@
 //! # #[cfg(feature = "k256")] {
 //! use enr::{k256::ecdsa::SigningKey, Enr};
 //! use std::net::Ipv4Addr;
-//! use rand::thread_rng;
+//! use rand::rng;
 //!
 //! // specify the type of ENR
 //! type DefaultEnr = Enr<SigningKey>;
 //!
 //! // generate a random secp256k1 key
-//! let mut rng = thread_rng();
+//! let mut rng = rng();
 //! let key = SigningKey::random(&mut rng);
 //!
 //! let ip = Ipv4Addr::new(192,168,0,1);
@@ -134,10 +134,10 @@
 //! # #[cfg(feature = "ed25519")] {
 //! use enr::{ed25519_dalek as ed25519, k256::ecdsa, CombinedKey, Enr};
 //! use std::net::Ipv4Addr;
-//! use rand::thread_rng;
+//! use rand::rng;
 //!
 //! // generate a random secp256k1 key
-//! let mut rng = thread_rng();
+//! let mut rng = rng();
 //! let key = ecdsa::SigningKey::random(&mut rng);
 //! let ip = Ipv4Addr::new(192,168,0,1);
 //! let enr_secp256k1 = Enr::builder().ip4(ip).tcp4(8000).build(&key).unwrap();
@@ -1401,7 +1401,7 @@ mod tests {
 
     #[test]
     fn test_encode_decode_list_value() {
-        let key = k256::ecdsa::SigningKey::random(&mut rand::thread_rng());
+        let key = k256::ecdsa::SigningKey::random(&mut rand::rng());
         let ip = Ipv4Addr::new(127, 0, 0, 1);
         let tcp = 3000;
         let list_value = GenericListValue::gen_random();
@@ -1437,7 +1437,7 @@ mod tests {
 
     #[test]
     fn test_encode_decode_double_list_value() {
-        let key = k256::ecdsa::SigningKey::random(&mut rand::thread_rng());
+        let key = k256::ecdsa::SigningKey::random(&mut rand::rng());
         let ip = Ipv4Addr::new(127, 0, 0, 1);
         let tcp = 3000;
         let list_value = DoubleListValue::gen_random();
@@ -1625,7 +1625,7 @@ mod tests {
     #[cfg(feature = "rust-secp256k1")]
     #[test]
     fn test_encode_decode_secp256k1() {
-        let mut rng = secp256k1::rand::thread_rng();
+        let mut rng = secp256k1::rand::rng();
         let key = secp256k1::SecretKey::new(&mut rng);
         let ip = Ipv4Addr::new(127, 0, 0, 1);
         let tcp = 3000;
@@ -1697,7 +1697,7 @@ mod tests {
     #[cfg(feature = "k256")]
     #[test]
     fn test_encode_decode_k256() {
-        let key = k256::ecdsa::SigningKey::random(&mut rand::thread_rng());
+        let key = k256::ecdsa::SigningKey::random(&mut rand::rng());
         let ip = Ipv4Addr::new(127, 0, 0, 1);
         let tcp = 3000;
 
@@ -1721,7 +1721,7 @@ mod tests {
     #[cfg(all(feature = "ed25519", feature = "k256"))]
     #[test]
     fn test_encode_decode_ed25519() {
-        let mut rng = rand::thread_rng();
+        let mut rng = rand::rng();
         let key = ed25519_dalek::SigningKey::generate(&mut rng);
         let ip = Ipv4Addr::new(10, 0, 0, 1);
         let tcp = 30303;
@@ -1747,7 +1747,7 @@ mod tests {
             version: u64,
         }
 
-        let mut rng = rand::thread_rng();
+        let mut rng = rand::rng();
         let key = k256::ecdsa::SigningKey::random(&mut rng);
         let proto = Proto {
             name: "test".to_string(),
@@ -1771,7 +1771,7 @@ mod tests {
             version: u64,
         }
 
-        let mut rng = rand::thread_rng();
+        let mut rng = rand::rng();
         let key = k256::ecdsa::SigningKey::random(&mut rng);
         let proto = Proto {
             name: "test".to_string(),
@@ -1795,7 +1795,7 @@ mod tests {
 
     #[test]
     fn test_add_key() {
-        let mut rng = rand::thread_rng();
+        let mut rng = rand::rng();
         let key = k256::ecdsa::SigningKey::random(&mut rng);
         let ip = Ipv4Addr::new(10, 0, 0, 1);
         let tcp = 30303;
@@ -1808,7 +1808,7 @@ mod tests {
 
     #[test]
     fn test_set_ip() {
-        let mut rng = rand::thread_rng();
+        let mut rng = rand::rng();
         let key = k256::ecdsa::SigningKey::random(&mut rng);
         let tcp = 30303;
         let ip = Ipv4Addr::new(10, 0, 0, 1);
@@ -1827,7 +1827,7 @@ mod tests {
 
     #[test]
     fn ip_mutation_static_node_id() {
-        let mut rng = rand::thread_rng();
+        let mut rng = rand::rng();
         let key = k256::ecdsa::SigningKey::random(&mut rng);
         let tcp = 30303;
         let udp = 30304;
@@ -1855,7 +1855,7 @@ mod tests {
     #[test]
     fn combined_key_can_decode_all() {
         // generate a random secp256k1 key
-        let key = k256::ecdsa::SigningKey::random(&mut rand::thread_rng());
+        let key = k256::ecdsa::SigningKey::random(&mut rand::rng());
         let ip = Ipv4Addr::new(192, 168, 0, 1);
         let enr_secp256k1 = Enr::builder().ip(ip.into()).tcp4(8000).build(&key).unwrap();
 
@@ -1863,7 +1863,7 @@ mod tests {
         let base64_string_secp256k1 = enr_secp256k1.to_base64();
 
         // generate a random ed25519 key
-        let key = ed25519_dalek::SigningKey::generate(&mut rand::thread_rng());
+        let key = ed25519_dalek::SigningKey::generate(&mut rand::rng());
         let enr_ed25519 = Enr::builder().ip(ip.into()).tcp4(8000).build(&key).unwrap();
 
         // encode to base64
@@ -1891,7 +1891,7 @@ mod tests {
 
     #[test]
     fn test_remove_insert() {
-        let mut rng = rand::thread_rng();
+        let mut rng = rand::rng();
         let key = k256::ecdsa::SigningKey::random(&mut rng);
         let tcp = 30303;
         let list = &["lighthouse", "eth_sync"];
@@ -1933,7 +1933,7 @@ mod tests {
 
     #[test]
     fn test_low_integer_build() {
-        let key = k256::ecdsa::SigningKey::random(&mut rand::thread_rng());
+        let key = k256::ecdsa::SigningKey::random(&mut rand::rng());
 
         for tcp in LOW_INT_PORTS {
             let enr = Enr::builder().tcp4(tcp).build(&key).unwrap();
@@ -1944,7 +1944,7 @@ mod tests {
 
     #[test]
     fn test_low_integer_set() {
-        let key = k256::ecdsa::SigningKey::random(&mut rand::thread_rng());
+        let key = k256::ecdsa::SigningKey::random(&mut rand::rng());
 
         for tcp in LOW_INT_PORTS {
             let mut enr = Enr::empty(&key).unwrap();
@@ -1955,7 +1955,7 @@ mod tests {
 
     #[test]
     fn test_low_integer_set_socket() {
-        let key = k256::ecdsa::SigningKey::random(&mut rand::thread_rng());
+        let key = k256::ecdsa::SigningKey::random(&mut rand::rng());
         let ipv4 = Ipv4Addr::new(127, 0, 0, 1);
 
         for tcp in LOW_INT_PORTS {
@@ -1968,7 +1968,7 @@ mod tests {
 
     #[test]
     fn test_low_integer_insert() {
-        let key = k256::ecdsa::SigningKey::random(&mut rand::thread_rng());
+        let key = k256::ecdsa::SigningKey::random(&mut rand::rng());
 
         for tcp in LOW_INT_PORTS {
             let mut enr = Enr::empty(&key).unwrap();
@@ -1985,7 +1985,7 @@ mod tests {
 
     #[test]
     fn test_low_integer_remove_insert() {
-        let key = k256::ecdsa::SigningKey::random(&mut rand::thread_rng());
+        let key = k256::ecdsa::SigningKey::random(&mut rand::rng());
 
         for tcp in LOW_INT_PORTS {
             let mut enr = Enr::empty(&key).unwrap();
@@ -2025,7 +2025,7 @@ mod tests {
 
     #[test]
     fn test_compare_content() {
-        let key = k256::ecdsa::SigningKey::random(&mut rand::thread_rng());
+        let key = k256::ecdsa::SigningKey::random(&mut rand::rng());
         let ip = Ipv4Addr::new(10, 0, 0, 1);
         let tcp = 30303;
 
@@ -2058,7 +2058,7 @@ mod tests {
     #[test]
     fn test_large_enr_decoding_is_rejected() {
         // hack an enr object that is too big. This is not possible via the public API.
-        let key = k256::ecdsa::SigningKey::random(&mut rand::thread_rng());
+        let key = k256::ecdsa::SigningKey::random(&mut rand::rng());
 
         let mut huge_enr = Enr::empty(&key).unwrap();
         let large_vec: Vec<u8> = std::iter::repeat(0).take(MAX_ENR_SIZE).collect();
@@ -2090,7 +2090,7 @@ mod tests {
             "eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4",
             "eHh4eHh4eHh4eHh4eHh4"
         );
-        let key = k256::ecdsa::SigningKey::random(&mut rand::thread_rng());
+        let key = k256::ecdsa::SigningKey::random(&mut rand::rng());
         let mut record = LARGE_ENR.parse::<DefaultEnr>().unwrap();
         let enr_bkp = record.clone();
         // verify that updating the sequence number when it won't fit is rejected
@@ -2104,7 +2104,7 @@ mod tests {
 
     #[test]
     fn test_set_client_eip7636() {
-        let key = k256::ecdsa::SigningKey::random(&mut rand::thread_rng());
+        let key = k256::ecdsa::SigningKey::random(&mut rand::rng());
         let mut enr = Enr::empty(&key).unwrap();
 
         enr.set_client_info(
@@ -2132,7 +2132,7 @@ mod tests {
         assert_eq!(info.1, "1.9.53");
         assert_eq!(info.2.unwrap(), "7fcb567");
 
-        let key = k256::ecdsa::SigningKey::random(&mut rand::thread_rng());
+        let key = k256::ecdsa::SigningKey::random(&mut rand::rng());
         let mut enr = Enr::empty(&key).unwrap();
 
         enr.set_client_info("Test".to_string(), "v1.0.0".to_string(), None, &key)
@@ -2146,7 +2146,7 @@ mod tests {
 
     #[test]
     fn test_builder_eip7636() {
-        let key = k256::ecdsa::SigningKey::random(&mut rand::thread_rng());
+        let key = k256::ecdsa::SigningKey::random(&mut rand::rng());
         let enr = Enr::builder()
             .ip4(Ipv4Addr::new(127, 0, 0, 1))
             .tcp4(30303)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1401,7 +1401,7 @@ mod tests {
 
     #[test]
     fn test_encode_decode_list_value() {
-        let key = k256::ecdsa::SigningKey::random(&mut rand::rngs::OsRng);
+        let key = k256::ecdsa::SigningKey::random(&mut rand::thread_rng());
         let ip = Ipv4Addr::new(127, 0, 0, 1);
         let tcp = 3000;
         let list_value = GenericListValue::gen_random();
@@ -1437,7 +1437,7 @@ mod tests {
 
     #[test]
     fn test_encode_decode_double_list_value() {
-        let key = k256::ecdsa::SigningKey::random(&mut rand::rngs::OsRng);
+        let key = k256::ecdsa::SigningKey::random(&mut rand::thread_rng());
         let ip = Ipv4Addr::new(127, 0, 0, 1);
         let tcp = 3000;
         let list_value = DoubleListValue::gen_random();
@@ -1697,7 +1697,7 @@ mod tests {
     #[cfg(feature = "k256")]
     #[test]
     fn test_encode_decode_k256() {
-        let key = k256::ecdsa::SigningKey::random(&mut rand::rngs::OsRng);
+        let key = k256::ecdsa::SigningKey::random(&mut rand::thread_rng());
         let ip = Ipv4Addr::new(127, 0, 0, 1);
         let tcp = 3000;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1284,8 +1284,8 @@ fn check_spec_reserved_keys(key: &[u8], mut value: &[u8]) -> Result<(), Error> {
 #[cfg(feature = "k256")]
 mod tests {
     use super::*;
-    use k256::elliptic_curve::Generate;
     use alloy_rlp::{RlpDecodable, RlpEncodable};
+    use k256::elliptic_curve::Generate;
 
     type DefaultEnr = Enr<k256::ecdsa::SigningKey>;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,12 +52,13 @@
 //! ```rust
 //! # #[cfg(feature = "k256")] {
 //! use enr::{Enr, k256};
+//! use k256::elliptic_curve::Generate;
 //! use std::net::Ipv4Addr;
 //! use rand::rng;
 //!
 //! // generate a random secp256k1 key
 //! let mut rng = rng();
-//! let key = k256::ecdsa::SigningKey::random(&mut rng);
+//! let key = k256::ecdsa::SigningKey::generate_from_rng(&mut rng);
 //!
 //! let ip = Ipv4Addr::new(192,168,0,1);
 //! let enr = Enr::builder().ip4(ip).tcp4(8000).build(&key).unwrap();
@@ -98,6 +99,7 @@
 //! ```rust
 //! # #[cfg(feature = "k256")] {
 //! use enr::{k256::ecdsa::SigningKey, Enr};
+//! use enr::k256::elliptic_curve::Generate;
 //! use std::net::Ipv4Addr;
 //! use rand::rng;
 //!
@@ -106,7 +108,7 @@
 //!
 //! // generate a random secp256k1 key
 //! let mut rng = rng();
-//! let key = SigningKey::random(&mut rng);
+//! let key = SigningKey::generate_from_rng(&mut rng);
 //!
 //! let ip = Ipv4Addr::new(192,168,0,1);
 //! let mut enr = Enr::builder().ip4(ip).tcp4(8000).build(&key).unwrap();
@@ -133,12 +135,13 @@
 //! ```rust
 //! # #[cfg(feature = "ed25519")] {
 //! use enr::{ed25519_dalek as ed25519, k256::ecdsa, CombinedKey, Enr};
+//! use enr::k256::elliptic_curve::Generate;
 //! use std::net::Ipv4Addr;
 //! use rand::rng;
 //!
 //! // generate a random secp256k1 key
 //! let mut rng = rng();
-//! let key = ecdsa::SigningKey::random(&mut rng);
+//! let key = ecdsa::SigningKey::generate_from_rng(&mut rng);
 //! let ip = Ipv4Addr::new(192,168,0,1);
 //! let enr_secp256k1 = Enr::builder().ip4(ip).tcp4(8000).build(&key).unwrap();
 //!
@@ -1281,6 +1284,7 @@ fn check_spec_reserved_keys(key: &[u8], mut value: &[u8]) -> Result<(), Error> {
 #[cfg(feature = "k256")]
 mod tests {
     use super::*;
+    use k256::elliptic_curve::Generate;
     use alloy_rlp::{RlpDecodable, RlpEncodable};
 
     type DefaultEnr = Enr<k256::ecdsa::SigningKey>;
@@ -1402,7 +1406,7 @@ mod tests {
 
     #[test]
     fn test_encode_decode_list_value() {
-        let key = k256::ecdsa::SigningKey::random(&mut rand::rng());
+        let key = k256::ecdsa::SigningKey::generate_from_rng(&mut rand::rng());
         let ip = Ipv4Addr::new(127, 0, 0, 1);
         let tcp = 3000;
         let list_value = GenericListValue::gen_random();
@@ -1438,7 +1442,7 @@ mod tests {
 
     #[test]
     fn test_encode_decode_double_list_value() {
-        let key = k256::ecdsa::SigningKey::random(&mut rand::rng());
+        let key = k256::ecdsa::SigningKey::generate_from_rng(&mut rand::rng());
         let ip = Ipv4Addr::new(127, 0, 0, 1);
         let tcp = 3000;
         let list_value = DoubleListValue::gen_random();
@@ -1700,7 +1704,7 @@ mod tests {
     #[cfg(feature = "k256")]
     #[test]
     fn test_encode_decode_k256() {
-        let key = k256::ecdsa::SigningKey::random(&mut rand::rng());
+        let key = k256::ecdsa::SigningKey::generate_from_rng(&mut rand::rng());
         let ip = Ipv4Addr::new(127, 0, 0, 1);
         let tcp = 3000;
 
@@ -1751,7 +1755,7 @@ mod tests {
         }
 
         let mut rng = rand::rng();
-        let key = k256::ecdsa::SigningKey::random(&mut rng);
+        let key = k256::ecdsa::SigningKey::generate_from_rng(&mut rng);
         let proto = Proto {
             name: "test".to_string(),
             version: 1,
@@ -1775,7 +1779,7 @@ mod tests {
         }
 
         let mut rng = rand::rng();
-        let key = k256::ecdsa::SigningKey::random(&mut rng);
+        let key = k256::ecdsa::SigningKey::generate_from_rng(&mut rng);
         let proto = Proto {
             name: "test".to_string(),
             version: 1,
@@ -1799,7 +1803,7 @@ mod tests {
     #[test]
     fn test_add_key() {
         let mut rng = rand::rng();
-        let key = k256::ecdsa::SigningKey::random(&mut rng);
+        let key = k256::ecdsa::SigningKey::generate_from_rng(&mut rng);
         let ip = Ipv4Addr::new(10, 0, 0, 1);
         let tcp = 30303;
 
@@ -1812,7 +1816,7 @@ mod tests {
     #[test]
     fn test_set_ip() {
         let mut rng = rand::rng();
-        let key = k256::ecdsa::SigningKey::random(&mut rng);
+        let key = k256::ecdsa::SigningKey::generate_from_rng(&mut rng);
         let tcp = 30303;
         let ip = Ipv4Addr::new(10, 0, 0, 1);
 
@@ -1831,7 +1835,7 @@ mod tests {
     #[test]
     fn ip_mutation_static_node_id() {
         let mut rng = rand::rng();
-        let key = k256::ecdsa::SigningKey::random(&mut rng);
+        let key = k256::ecdsa::SigningKey::generate_from_rng(&mut rng);
         let tcp = 30303;
         let udp = 30304;
         let ip = Ipv4Addr::new(10, 0, 0, 1);
@@ -1858,7 +1862,7 @@ mod tests {
     #[test]
     fn combined_key_can_decode_all() {
         // generate a random secp256k1 key
-        let key = k256::ecdsa::SigningKey::random(&mut rand::rng());
+        let key = k256::ecdsa::SigningKey::generate_from_rng(&mut rand::rng());
         let ip = Ipv4Addr::new(192, 168, 0, 1);
         let enr_secp256k1 = Enr::builder().ip(ip.into()).tcp4(8000).build(&key).unwrap();
 
@@ -1895,7 +1899,7 @@ mod tests {
     #[test]
     fn test_remove_insert() {
         let mut rng = rand::rng();
-        let key = k256::ecdsa::SigningKey::random(&mut rng);
+        let key = k256::ecdsa::SigningKey::generate_from_rng(&mut rng);
         let tcp = 30303;
         let list = &["lighthouse", "eth_sync"];
         let out = encoded_list(list);
@@ -1936,7 +1940,7 @@ mod tests {
 
     #[test]
     fn test_low_integer_build() {
-        let key = k256::ecdsa::SigningKey::random(&mut rand::rng());
+        let key = k256::ecdsa::SigningKey::generate_from_rng(&mut rand::rng());
 
         for tcp in LOW_INT_PORTS {
             let enr = Enr::builder().tcp4(tcp).build(&key).unwrap();
@@ -1947,7 +1951,7 @@ mod tests {
 
     #[test]
     fn test_low_integer_set() {
-        let key = k256::ecdsa::SigningKey::random(&mut rand::rng());
+        let key = k256::ecdsa::SigningKey::generate_from_rng(&mut rand::rng());
 
         for tcp in LOW_INT_PORTS {
             let mut enr = Enr::empty(&key).unwrap();
@@ -1958,7 +1962,7 @@ mod tests {
 
     #[test]
     fn test_low_integer_set_socket() {
-        let key = k256::ecdsa::SigningKey::random(&mut rand::rng());
+        let key = k256::ecdsa::SigningKey::generate_from_rng(&mut rand::rng());
         let ipv4 = Ipv4Addr::new(127, 0, 0, 1);
 
         for tcp in LOW_INT_PORTS {
@@ -1971,7 +1975,7 @@ mod tests {
 
     #[test]
     fn test_low_integer_insert() {
-        let key = k256::ecdsa::SigningKey::random(&mut rand::rng());
+        let key = k256::ecdsa::SigningKey::generate_from_rng(&mut rand::rng());
 
         for tcp in LOW_INT_PORTS {
             let mut enr = Enr::empty(&key).unwrap();
@@ -1988,7 +1992,7 @@ mod tests {
 
     #[test]
     fn test_low_integer_remove_insert() {
-        let key = k256::ecdsa::SigningKey::random(&mut rand::rng());
+        let key = k256::ecdsa::SigningKey::generate_from_rng(&mut rand::rng());
 
         for tcp in LOW_INT_PORTS {
             let mut enr = Enr::empty(&key).unwrap();
@@ -2028,7 +2032,7 @@ mod tests {
 
     #[test]
     fn test_compare_content() {
-        let key = k256::ecdsa::SigningKey::random(&mut rand::rng());
+        let key = k256::ecdsa::SigningKey::generate_from_rng(&mut rand::rng());
         let ip = Ipv4Addr::new(10, 0, 0, 1);
         let tcp = 30303;
 
@@ -2061,7 +2065,7 @@ mod tests {
     #[test]
     fn test_large_enr_decoding_is_rejected() {
         // hack an enr object that is too big. This is not possible via the public API.
-        let key = k256::ecdsa::SigningKey::random(&mut rand::rng());
+        let key = k256::ecdsa::SigningKey::generate_from_rng(&mut rand::rng());
 
         let mut huge_enr = Enr::empty(&key).unwrap();
         let large_vec: Vec<u8> = std::iter::repeat_n(0, MAX_ENR_SIZE).collect();
@@ -2093,7 +2097,7 @@ mod tests {
             "eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4",
             "eHh4eHh4eHh4eHh4eHh4"
         );
-        let key = k256::ecdsa::SigningKey::random(&mut rand::rng());
+        let key = k256::ecdsa::SigningKey::generate_from_rng(&mut rand::rng());
         let mut record = LARGE_ENR.parse::<DefaultEnr>().unwrap();
         let enr_bkp = record.clone();
         // verify that updating the sequence number when it won't fit is rejected
@@ -2107,7 +2111,7 @@ mod tests {
 
     #[test]
     fn test_set_client_eip7636() {
-        let key = k256::ecdsa::SigningKey::random(&mut rand::rng());
+        let key = k256::ecdsa::SigningKey::generate_from_rng(&mut rand::rng());
         let mut enr = Enr::empty(&key).unwrap();
 
         #[allow(deprecated)]
@@ -2138,7 +2142,7 @@ mod tests {
         assert_eq!(info.1, "1.9.53");
         assert_eq!(info.2.unwrap(), "7fcb567");
 
-        let key = k256::ecdsa::SigningKey::random(&mut rand::rng());
+        let key = k256::ecdsa::SigningKey::generate_from_rng(&mut rand::rng());
         let mut enr = Enr::empty(&key).unwrap();
 
         #[allow(deprecated)]
@@ -2154,7 +2158,7 @@ mod tests {
 
     #[test]
     fn test_builder_eip7636() {
-        let key = k256::ecdsa::SigningKey::random(&mut rand::rng());
+        let key = k256::ecdsa::SigningKey::generate_from_rng(&mut rand::rng());
 
         #[allow(deprecated)]
         let enr = Enr::builder()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -691,10 +691,10 @@ impl<K: EnrKey> Enr<K> {
         build: Option<String>,
         key: &K,
     ) -> Result<(), Error> {
-        if build.is_none() {
-            self.insert("client", &vec![name, version], key)?;
+        if let Some(build) = build {
+            self.insert("client", &vec![name, version, build], key)?;
         } else {
-            self.insert("client", &vec![name, version, build.unwrap()], key)?;
+            self.insert("client", &vec![name, version], key)?;
         }
 
         Ok(())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1680,13 +1680,15 @@ mod tests {
         // ```
         let expected_enr_base64 = "enr:-IS4QLJYdRwxdy-AbzWC6wL9ooB6O6uvCvJsJ36rbJztiAs1JzPY0__YkgFzZwNUuNhm1BDN6c4-UVRCJP9bXNCmoDYBgmlkgnY0gmlwhH8AAAGJc2VjcDI1NmsxoQPKY0yuDUmstAHYpMa2_oxVtw0RW_QAdpzBQA8yWM0xOIN1ZHCCdl8";
 
-        let key_data =
+        let key_data: [u8; 32] =
             hex::decode("b71c71a67e1177ad4e901695e1b4b9ee17ae16c6668d313eac2f96dbcda3f291")
+                .unwrap()
+                .try_into()
                 .unwrap();
         let ip = Ipv4Addr::new(127, 0, 0, 1);
         let udp = 30303;
 
-        let key = secp256k1::SecretKey::from_slice(&key_data).unwrap();
+        let key = secp256k1::SecretKey::from_byte_array(key_data).unwrap();
         let enr = Enr::builder().ip4(ip).udp4(udp).build(&key).unwrap();
         let enr_base64 = enr.to_base64();
         assert_eq!(enr_base64, expected_enr_base64);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1643,7 +1643,7 @@ mod tests {
         // Must compare encoding as the public key itself can be different
         assert_eq!(
             decoded_enr.public_key().encode(),
-            key.public().encode().into()
+            Into::<[u8; 33]>::into(key.public().encode())
         );
         assert!(decoded_enr.verify());
     }

--- a/tests/ecdsa/rust_secp256k1.rs
+++ b/tests/ecdsa/rust_secp256k1.rs
@@ -7,12 +7,14 @@ use std::net::Ipv4Addr;
 fn test_secp256k1_sign_ecdsa_with_noncedata() {
     let not_expected_enr_base64 = "enr:-IS4QLJYdRwxdy-AbzWC6wL9ooB6O6uvCvJsJ36rbJztiAs1JzPY0__YkgFzZwNUuNhm1BDN6c4-UVRCJP9bXNCmoDYBgmlkgnY0gmlwhH8AAAGJc2VjcDI1NmsxoQPKY0yuDUmstAHYpMa2_oxVtw0RW_QAdpzBQA8yWM0xOIN1ZHCCdl8";
 
-    let key_data =
-        hex::decode("b71c71a67e1177ad4e901695e1b4b9ee17ae16c6668d313eac2f96dbcda3f291").unwrap();
+    let key_data = hex::decode("b71c71a67e1177ad4e901695e1b4b9ee17ae16c6668d313eac2f96dbcda3f291")
+        .unwrap()
+        .try_into()
+        .unwrap();
     let ip = Ipv4Addr::new(127, 0, 0, 1);
     let udp = 30303;
 
-    let key = secp256k1::SecretKey::from_slice(&key_data).unwrap();
+    let key = secp256k1::SecretKey::from_byte_array(key_data).unwrap();
     let enr = Enr::builder().ip4(ip).udp4(udp).build(&key).unwrap();
     let enr_base64 = enr.to_base64();
     assert_ne!(enr_base64, not_expected_enr_base64);


### PR DESCRIPTION
This PR closes #88

## Dependency updates

| crate | before | after | 
| --- | --- | --- | 
| `rand` | `0.8` | `0.10` | 
| `sha3` | `0.10` | `0.11` | 
| `k256` | `0.13` | `0.14` | 
| `ed25519-dalek` | `2.1` | `3.0` | 
| `secp256k1` | `0.30` | `0.31` | 

## Breaking changes

This needs a new minor release.

- [CombinedKey](https://github.com/sigp/enr/blob/5bd772c45e8f4ed9b74d646c65d39d514f1cca81/src/keys/combined.rs#L16-L21) variants expose `k256::ecdsa::SigningKey` and `ed25519::SigningKey` directly, and [EnrKey](https://github.com/sigp/enr/blob/5bd772c45e8f4ed9b74d646c65d39d514f1cca81/src/keys/combined.rs#L35) is only implemented for the new versions. Downstream creates that depend on `k256` / `ed25519-dalek` directly must upgrade, or the key types will no longer unify.



